### PR TITLE
Feat/UI setup

### DIFF
--- a/src/components/login-form.tsx
+++ b/src/components/login-form.tsx
@@ -50,6 +50,7 @@ export const LoginForm = ({ className, ...props }: React.ComponentProps<"div">) 
               <Field>
                 <FieldLabel htmlFor="password">Password</FieldLabel>
                 <Input
+                  aria-invalid={!!error}
                   id="password"
                   type="password"
                   value={password}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -10,11 +10,11 @@ const buttonVariants = cva(
       variant: {
         default: "font-bold bg-primary text-primary-foreground hover:bg-primary/80",
         outline:
-          "border-primary font-bold bg-background shadow-xs hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 text-primary",
+          "border-primary hover:bg-gray-100 font-bold bg-background shadow-xs hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 text-primary",
         secondary:
           "font-bold bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
         ghost:
-          "font-bold hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+          "font-bold hover:bg-muted hover:text-foreground hover:underline aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
         destructive:
           "font-bold bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
         link: "text-primary underline-offset-4 hover:underline",

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,24 +4,24 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "#/lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "font-serif cursor-pointer font-bold group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding text-sm whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/80",
+        default: "font-bold bg-primary text-primary-foreground hover:bg-primary/80",
         outline:
-          "border-border bg-background shadow-xs hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+          "border-primary font-bold bg-background shadow-xs hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50 text-primary",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+          "font-bold bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
         ghost:
-          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+          "font-bold hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
         destructive:
-          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
+          "font-bold bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
         default:
-          "h-9 gap-1.5 px-2.5 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+          "h-9 gap-2 px-5 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
         xs: "h-6 gap-1 rounded-[min(var(--radius-md),8px)] px-2 text-xs in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
         sm: "h-8 gap-1 rounded-[min(var(--radius-md),10px)] px-2.5 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5",
         lg: "h-10 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ const Input = ({ className, type, ...props }: React.ComponentProps<"input">) => 
       type={type}
       data-slot="input"
       className={cn(
-        "h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-2.5 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        "h-9 w-full min-w-0 rounded-md border border-border bg-transparent px-2.5 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className,
       )}
       {...props}

--- a/src/components/ui/search-bar.tsx
+++ b/src/components/ui/search-bar.tsx
@@ -1,0 +1,185 @@
+"use client"
+
+import * as React from "react"
+import { Search } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { SearchResultList, type SearchResultItem } from "./search-result-list"
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface SearchBarBaseProps {
+  placeholder?: string
+  /** Called on input value change (both modes) */
+  onQueryChange?: (query: string) => void
+  /** Called when the search icon / Enter key is pressed (both modes) */
+  onSearch?: (query: string) => void
+  className?: string
+  /** Initial / controlled value */
+  value?: string
+  /** aria-label for the input */
+  inputAriaLabel?: string
+}
+
+/** Standalone bar – no results dropdown */
+interface SearchBarStandaloneProps extends SearchBarBaseProps {
+  type: "standalone"
+}
+
+/** Integrated bar – dropdown opens when focused / query changes */
+interface SearchBarIntegratedProps extends SearchBarBaseProps {
+  type: "integrated"
+  /** Items to show in the dropdown */
+  results: SearchResultItem[]
+  onResultClick?: (item: SearchResultItem) => void
+  /** Show results even when query is empty (like Google Maps on focus) */
+  showResultsWhenEmpty?: boolean
+}
+
+export type SearchBarProps = SearchBarStandaloneProps | SearchBarIntegratedProps
+
+// ─── SearchBar ────────────────────────────────────────────────────────────────
+
+export function SearchBar(props: SearchBarProps) {
+  const {
+    placeholder = "Search",
+    onQueryChange,
+    onSearch,
+    className,
+    value: controlledValue,
+    inputAriaLabel,
+  } = props
+
+  const [internalQuery, setInternalQuery] = React.useState(controlledValue ?? "")
+  const [isFocused, setIsFocused] = React.useState(false)
+  const wrapperRef = React.useRef<HTMLDivElement>(null)
+
+  const query = controlledValue !== undefined ? controlledValue : internalQuery
+
+  // Sync if controlled
+  React.useEffect(() => {
+    if (controlledValue !== undefined) setInternalQuery(controlledValue)
+  }, [controlledValue])
+
+  // Close dropdown when clicking outside
+  React.useEffect(() => {
+    if (props.type !== "integrated") return
+    function handlePointerDown(e: PointerEvent) {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setIsFocused(false)
+      }
+    }
+    document.addEventListener("pointerdown", handlePointerDown)
+    return () => document.removeEventListener("pointerdown", handlePointerDown)
+  }, [props.type])
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const val = e.target.value
+    if (controlledValue === undefined) setInternalQuery(val)
+    onQueryChange?.(val)
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      onSearch?.(query)
+      if (props.type === "integrated") setIsFocused(false)
+    }
+    if (e.key === "Escape" && props.type === "integrated") {
+      setIsFocused(false)
+    }
+  }
+
+  // ── Integrated mode (rounded, dropdown overlays content) ─────────────────
+
+  if (props.type === "integrated") {
+    const { results, onResultClick, showResultsWhenEmpty = true } = props
+
+    const showDropdown =
+      isFocused && (showResultsWhenEmpty || query.length > 0) && results.length > 0
+
+    return (
+      <div ref={wrapperRef} className={cn("relative w-full", className)}>
+        {/* Search bar */}
+        <div
+          className={cn(
+            "bg-card shadow-md border border-border/60 overflow-hidden",
+            showDropdown ? "rounded-t-2xl rounded-b-none" : "rounded-full",
+          )}
+        >
+          {/* Input row */}
+          <div className="flex items-center gap-3 px-4 py-3">
+            <Search className="w-5 h-5 text-muted-foreground shrink-0" aria-hidden="true" />
+            <input
+              type="search"
+              value={query}
+              onChange={handleChange}
+              onFocus={() => setIsFocused(true)}
+              onKeyDown={handleKeyDown}
+              placeholder={placeholder}
+              aria-label={inputAriaLabel ?? placeholder}
+              aria-expanded={showDropdown}
+              aria-autocomplete="list"
+              aria-controls={showDropdown ? "search-results-dropdown" : undefined}
+              role="combobox"
+              className={cn(
+                "flex-1 min-w-0 bg-transparent text-foreground",
+                "placeholder:text-muted-foreground",
+                "text-base leading-6",
+                "focus:outline-none",
+                "[&::-webkit-search-cancel-button]:hidden",
+              )}
+            />
+          </div>
+        </div>
+
+        {/* Dropdown results – positioned absolutely to overlay content */}
+        {showDropdown && (
+          <div
+            id="search-results-dropdown"
+            className="absolute left-0 right-0 top-full z-50 bg-card border border-t-0 border-border/60 rounded-b-2xl shadow-lg overflow-hidden"
+          >
+            <div className="h-px bg-border" />
+            <SearchResultList
+              items={results}
+              onItemClick={(item) => {
+                onResultClick?.(item)
+                setIsFocused(false)
+              }}
+              bare
+            />
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  // ── Standalone mode (more square/rectangular) ────────────────────────────
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 px-4 py-3",
+        "bg-card rounded-lg shadow-md border border-border/60",
+        className,
+      )}
+    >
+      <Search className="w-5 h-5 text-muted-foreground shrink-0" aria-hidden="true" />
+      <input
+        type="search"
+        value={query}
+        onChange={handleChange}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        aria-label={inputAriaLabel ?? placeholder}
+        className={cn(
+          "flex-1 min-w-0 bg-transparent text-foreground",
+          "placeholder:text-muted-foreground",
+          "text-base leading-6",
+          "focus:outline-none",
+          "[&::-webkit-search-cancel-button]:hidden",
+        )}
+      />
+    </div>
+  )
+}

--- a/src/components/ui/search-result-list.tsx
+++ b/src/components/ui/search-result-list.tsx
@@ -1,0 +1,116 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface SearchResultItem {
+  id: string
+  /** Icon rendered inside the circular badge */
+  icon: React.ReactNode
+  /** Background colour of the icon circle (Tailwind class or CSS variable) */
+  iconBg?: string
+  /** Primary label */
+  title: string
+  /** Semantic description – e.g. "Software lecture room", "Metro station" */
+  semantic?: string
+}
+
+export interface SearchResultListProps {
+  items: SearchResultItem[]
+  onItemClick?: (item: SearchResultItem) => void
+  className?: string
+  /** Optionally hide the outer rounded card container (useful when embedded) */
+  bare?: boolean
+}
+
+// ─── Individual result row ────────────────────────────────────────────────────
+
+function ResultRow({
+  item,
+  onItemClick,
+  showSeparator = false,
+}: {
+  item: SearchResultItem
+  onItemClick?: (item: SearchResultItem) => void
+  showSeparator?: boolean
+}) {
+  return (
+    <li>
+      {showSeparator && <div className="h-px bg-border" aria-hidden="true" />}
+      <button
+        type="button"
+        onClick={() => onItemClick?.(item)}
+        className={cn(
+          "w-full flex items-center gap-3 px-4 py-3 text-left cursor-pointer",
+          "hover:bg-muted focus-visible:bg-muted",
+          "focus-visible:outline-none",
+        )}
+      >
+        {/* Icon badge */}
+        <span
+          className={cn(
+            "shrink-0 w-9 h-9 sm:w-10 sm:h-10 rounded-full flex items-center justify-center",
+            item.iconBg ?? "bg-primary",
+          )}
+          aria-hidden="true"
+        >
+          <span className="text-white w-4 h-4 sm:w-5 sm:h-5 flex items-center justify-center">
+            {item.icon}
+          </span>
+        </span>
+
+        {/* Text block */}
+        <span className="flex-1 min-w-0">
+          <span className="block font-medium text-foreground text-sm leading-snug truncate">
+            {item.title}
+          </span>
+          {item.semantic && (
+            <span className="block text-xs text-muted-foreground leading-snug truncate mt-0.5">
+              {item.semantic}
+            </span>
+          )}
+        </span>
+      </button>
+    </li>
+  )
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export function SearchResultList({
+  items,
+  onItemClick,
+  className,
+  bare = false,
+}: SearchResultListProps) {
+  if (items.length === 0) return null
+
+  const content = (
+    <ul role="listbox" aria-label="Search results">
+      {items.map((item, index) => (
+        <ResultRow key={item.id} item={item} onItemClick={onItemClick} showSeparator={index > 0} />
+      ))}
+    </ul>
+  )
+
+  if (bare) {
+    return (
+      <div className={cn("w-full", className)} role="region" aria-label="Search results">
+        {content}
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className={cn(
+        "w-full bg-card rounded-sm shadow-md border border-border/60 overflow-hidden",
+        className,
+      )}
+      role="region"
+      aria-label="Search results"
+    >
+      {content}
+    </div>
+  )
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,11 +9,17 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as UiDemoRouteImport } from './routes/ui-demo'
 import { Route as TestImportRouteImport } from './routes/test-import'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
 
+const UiDemoRoute = UiDemoRouteImport.update({
+  id: '/ui-demo',
+  path: '/ui-demo',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const TestImportRoute = TestImportRouteImport.update({
   id: '/test-import',
   path: '/test-import',
@@ -39,12 +45,14 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
   '/test-import': typeof TestImportRoute
+  '/ui-demo': typeof UiDemoRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
   '/test-import': typeof TestImportRoute
+  '/ui-demo': typeof UiDemoRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
 }
 export interface FileRoutesById {
@@ -52,25 +60,34 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
   '/test-import': typeof TestImportRoute
+  '/ui-demo': typeof UiDemoRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/login' | '/test-import' | '/api/auth/$'
+  fullPaths: '/' | '/login' | '/test-import' | '/ui-demo' | '/api/auth/$'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/login' | '/test-import' | '/api/auth/$'
-  id: '__root__' | '/' | '/login' | '/test-import' | '/api/auth/$'
+  to: '/' | '/login' | '/test-import' | '/ui-demo' | '/api/auth/$'
+  id: '__root__' | '/' | '/login' | '/test-import' | '/ui-demo' | '/api/auth/$'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   LoginRoute: typeof LoginRoute
   TestImportRoute: typeof TestImportRoute
+  UiDemoRoute: typeof UiDemoRoute
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/ui-demo': {
+      id: '/ui-demo'
+      path: '/ui-demo'
+      fullPath: '/ui-demo'
+      preLoaderRoute: typeof UiDemoRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/test-import': {
       id: '/test-import'
       path: '/test-import'
@@ -106,6 +123,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   LoginRoute: LoginRoute,
   TestImportRoute: TestImportRoute,
+  UiDemoRoute: UiDemoRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
 }
 export const routeTree = rootRouteImport

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -13,13 +13,11 @@ interface MyRouterContext {
   queryClient: QueryClient
 }
 
-const THEME_INIT_SCRIPT = `(function(){try{var stored=window.localStorage.getItem('theme');var mode=(stored==='light'||stored==='dark'||stored==='auto')?stored:'auto';var prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;var resolved=mode==='auto'?(prefersDark?'dark':'light'):mode;var root=document.documentElement;root.classList.remove('light','dark');root.classList.add(resolved);if(mode==='auto'){root.removeAttribute('data-theme')}else{root.setAttribute('data-theme',mode)}root.style.colorScheme=resolved;}catch(e){}})();`
-
 const RootDocument = ({ children }: Readonly<{ children: React.ReactNode }>) => {
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
+        <script dangerouslySetInnerHTML={{ __html: "light" }} />
         <HeadContent />
       </head>
       <body className="font-sans antialiased wrap-anywhere selection:bg-[rgba(79,184,178,0.24)]">

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -23,7 +23,7 @@ const App = () => {
               Sign out
             </Button>
           ) : (
-            <Link to="/login" className={buttonVariants({ variant: "outline" })}>
+            <Link to="/login" className={buttonVariants({ variant: "default" })}>
               Admin Login
             </Link>
           ))}

--- a/src/routes/ui-demo.tsx
+++ b/src/routes/ui-demo.tsx
@@ -1,0 +1,188 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { Building2, MapPin, GraduationCap, Coffee, Train } from "lucide-react"
+import * as React from "react"
+
+import { Button } from "#/components/ui/button"
+import { Input } from "#/components/ui/input"
+
+import { SearchBar } from "../components/ui/search-bar"
+import { SearchResultList, type SearchResultItem } from "../components/ui/search-result-list"
+
+// ─── Demo data ────────────────────────────────────────────────────────────────
+
+const ALL_RESULTS: SearchResultItem[] = [
+  {
+    id: "lecture-hall",
+    icon: <GraduationCap className="w-5 h-5" />,
+    title: "Building 101",
+    semantic: "Software lecture room",
+  },
+  {
+    id: "library",
+    icon: <Building2 className="w-5 h-5" />,
+    title: "Main Library",
+    semantic: "University library",
+  },
+  {
+    id: "station",
+    icon: <Train className="w-5 h-5" />,
+    title: "Central Station",
+    semantic: "Train station",
+  },
+  {
+    id: "coffee",
+    icon: <Coffee className="w-5 h-5" />,
+    title: "Campus Coffee",
+    semantic: "Coffee shop",
+  },
+]
+
+const NEARBY_RESULTS: SearchResultItem[] = [
+  {
+    id: "auditorium",
+    icon: <Building2 className="w-5 h-5" />,
+    title: "Auditorium A",
+    semantic: "Main auditorium",
+  },
+  {
+    id: "canteen",
+    icon: <MapPin className="w-5 h-5" />,
+    title: "Student Canteen",
+    semantic: "Cafeteria",
+  },
+  {
+    id: "parking",
+    icon: <MapPin className="w-5 h-5" />,
+    title: "Parking Lot B",
+    semantic: "Parking area",
+  },
+]
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+const DemoPage = () => {
+  const [standaloneQuery, setStandaloneQuery] = React.useState("")
+  const [integratedQuery, setIntegratedQuery] = React.useState("")
+
+  // Filter results by query for the integrated bar
+  const filteredResults = integratedQuery
+    ? ALL_RESULTS.filter(
+        (r) =>
+          r.title.toLowerCase().includes(integratedQuery.toLowerCase()) ||
+          r.semantic?.toLowerCase().includes(integratedQuery.toLowerCase()),
+      )
+    : ALL_RESULTS
+
+  return (
+    <main className="min-h-screen bg-background font-sans">
+      {/* Simulated map background */}
+      <div
+        className="fixed inset-0 -z-10"
+        style={{
+          backgroundImage: `
+            linear-gradient(rgba(200,220,200,0.4) 1px, transparent 1px),
+            linear-gradient(90deg, rgba(200,220,200,0.4) 1px, transparent 1px)
+          `,
+          backgroundSize: "40px 40px",
+          backgroundColor: "#e8f0e8",
+        }}
+        aria-hidden="true"
+      />
+
+      <div className="max-w-lg mx-auto px-4 py-10 space-y-12">
+        {/* ── Section 1: Integrated bar ───────────────────────────────── */}
+        <section aria-labelledby="integrated-heading">
+          <h2
+            id="integrated-heading"
+            className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-3"
+          >
+            SearchBar — type=&quot;integrated&quot;
+          </h2>
+          <SearchBar
+            type="integrated"
+            placeholder="Search locations..."
+            value={integratedQuery}
+            onQueryChange={setIntegratedQuery}
+            onSearch={(q) => {
+              console.log("Search:", q)
+            }}
+            results={filteredResults}
+            onResultClick={(item) => {
+              console.log("Selected:", item.title)
+            }}
+          />
+          <p className="text-xs text-muted-foreground mt-3">
+            Click on the search bar to see the dropdown overlay
+          </p>
+        </section>
+
+        {/* ── Section 2: Standalone bar ───────────────────────────────── */}
+        <section aria-labelledby="standalone-heading">
+          <h2
+            id="standalone-heading"
+            className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-3"
+          >
+            SearchBar — type=&quot;standalone&quot;
+          </h2>
+          <SearchBar
+            type="standalone"
+            placeholder="Search..."
+            value={standaloneQuery}
+            onQueryChange={setStandaloneQuery}
+            onSearch={(q) => {
+              console.log("Search:", q)
+            }}
+          />
+        </section>
+
+        {/* ── Section 3: SearchResultList standalone ──────────────────── */}
+        <section aria-labelledby="results-heading">
+          <h2
+            id="results-heading"
+            className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-3"
+          >
+            SearchResultList — standalone
+          </h2>
+          <SearchResultList
+            items={NEARBY_RESULTS}
+            onItemClick={(item) => {
+              console.log("Clicked:", item.title)
+            }}
+          />
+        </section>
+
+        {/* ── Section 4: Shadcn basics ───────────────────────────── */}
+        <section aria-labelledby="shadcn-heading">
+          <h2
+            id="shadcn-heading"
+            className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-3"
+          >
+            Shadcn — basics
+          </h2>
+
+          <div className="space-y-4">
+            {/* Inputs */}
+            <div className="space-y-2">
+              <Input placeholder="Default input" />
+              <Input placeholder="Disabled input" disabled />
+              <Input placeholder="Error input" aria-invalid={true} />
+            </div>
+
+            {/* Buttons */}
+            <div className="flex flex-wrap gap-2">
+              <Button>Default</Button>
+              <Button variant="secondary">Secondary</Button>
+              <Button variant="outline">Outline</Button>
+              <Button variant="ghost">Ghost</Button>
+              <Button variant="destructive">Destructive</Button>
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+  )
+}
+
+export const Route = createFileRoute("/ui-demo")({
+  component: DemoPage,
+})

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,386 +1,167 @@
-@import url("https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,700&family=Manrope:wght@400;500;600;700;800&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700&family=Montserrat:wght@400;500;600;700&display=swap");
 @import "tailwindcss";
-@import "tw-animate-css";
-@import "shadcn/tailwind.css";
-@import "@fontsource-variable/inter";
 
 @custom-variant dark (&:is(.dark *));
-@plugin "@tailwindcss/typography";
-
-@theme {
-  --font-sans: "Manrope", ui-sans-serif, system-ui, sans-serif;
-}
 
 :root {
-  --sea-ink: #173a40;
-  --sea-ink-soft: #416166;
-  --lagoon: #4fb8b2;
-  --lagoon-deep: #328f97;
-  --palm: #2f6a4a;
-  --sand: #e7f0e8;
-  --foam: #f3faf5;
-  --surface: rgba(255, 255, 255, 0.74);
-  --surface-strong: rgba(255, 255, 255, 0.9);
-  --line: rgba(23, 58, 64, 0.14);
-  --inset-glint: rgba(255, 255, 255, 0.82);
-  --kicker: rgba(47, 106, 74, 0.9);
-  --bg-base: #e7f3ec;
-  --header-bg: rgba(251, 255, 248, 0.84);
-  --chip-bg: rgba(255, 255, 255, 0.8);
-  --chip-line: rgba(47, 106, 74, 0.18);
-  --link-bg-hover: rgba(255, 255, 255, 0.9);
-  --hero-a: rgba(79, 184, 178, 0.36);
-  --hero-b: rgba(47, 106, 74, 0.2);
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
+  --background: oklch(0.985 0 0);
+  --foreground: oklch(0.3211 0 0);
   --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.809 0.105 251.813);
-  --chart-2: oklch(0.623 0.214 259.815);
-  --chart-3: oklch(0.546 0.245 262.881);
-  --chart-4: oklch(0.488 0.243 264.376);
-  --chart-5: oklch(0.424 0.199 265.638);
-  --radius: 0.625rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
-}
-
-:root[data-theme="dark"] {
-  --sea-ink: #d7ece8;
-  --sea-ink-soft: #afcdc8;
-  --lagoon: #60d7cf;
-  --lagoon-deep: #8de5db;
-  --palm: #6ec89a;
-  --sand: #0f1a1e;
-  --foam: #101d22;
-  --surface: rgba(16, 30, 34, 0.8);
-  --surface-strong: rgba(15, 27, 31, 0.92);
-  --line: rgba(141, 229, 219, 0.18);
-  --inset-glint: rgba(194, 247, 238, 0.14);
-  --kicker: #b8efe5;
-  --bg-base: #0a1418;
-  --header-bg: rgba(10, 20, 24, 0.8);
-  --chip-bg: rgba(13, 28, 32, 0.9);
-  --chip-line: rgba(141, 229, 219, 0.24);
-  --link-bg-hover: rgba(24, 44, 49, 0.8);
-  --hero-a: rgba(96, 215, 207, 0.18);
-  --hero-b: rgba(110, 200, 154, 0.12);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) {
-    --sea-ink: #d7ece8;
-    --sea-ink-soft: #afcdc8;
-    --lagoon: #60d7cf;
-    --lagoon-deep: #8de5db;
-    --palm: #6ec89a;
-    --sand: #0f1a1e;
-    --foam: #101d22;
-    --surface: rgba(16, 30, 34, 0.8);
-    --surface-strong: rgba(15, 27, 31, 0.92);
-    --line: rgba(141, 229, 219, 0.18);
-    --inset-glint: rgba(194, 247, 238, 0.14);
-    --kicker: #b8efe5;
-    --bg-base: #0a1418;
-    --header-bg: rgba(10, 20, 24, 0.8);
-    --chip-bg: rgba(13, 28, 32, 0.9);
-    --chip-line: rgba(141, 229, 219, 0.24);
-    --link-bg-hover: rgba(24, 44, 49, 0.8);
-    --hero-a: rgba(96, 215, 207, 0.18);
-    --hero-b: rgba(110, 200, 154, 0.12);
-  }
-}
-
-* {
-  box-sizing: border-box;
-}
-
-html,
-body,
-#app {
-  min-height: 100%;
-}
-
-body {
-  margin: 0;
-  color: var(--sea-ink);
-  font-family: var(--font-sans);
-  background-color: var(--bg-base);
-  background:
-    radial-gradient(1100px 620px at -8% -10%, var(--hero-a), transparent 58%),
-    radial-gradient(1050px 620px at 112% -12%, var(--hero-b), transparent 62%),
-    radial-gradient(720px 380px at 50% 115%, rgba(79, 184, 178, 0.1), transparent 68%),
-    linear-gradient(
-      180deg,
-      color-mix(in oklab, var(--sand) 68%, white) 0%,
-      var(--foam) 44%,
-      var(--bg-base) 100%
-    );
-  overflow-x: hidden;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-body::before {
-  content: "";
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  z-index: -1;
-  opacity: 0.28;
-  background:
-    radial-gradient(circle at 20% 15%, rgba(255, 255, 255, 0.8), transparent 34%),
-    radial-gradient(circle at 78% 26%, rgba(79, 184, 178, 0.2), transparent 42%),
-    radial-gradient(circle at 42% 82%, rgba(47, 106, 74, 0.14), transparent 36%);
-}
-
-body::after {
-  content: "";
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  z-index: -1;
-  opacity: 0.14;
-  background-image:
-    linear-gradient(rgba(255, 255, 255, 0.07) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255, 255, 255, 0.06) 1px, transparent 1px);
-  background-size: 28px 28px;
-  mask-image: radial-gradient(circle at 50% 30%, black, transparent 78%);
-}
-
-a {
-  color: var(--lagoon-deep);
-  text-decoration-color: rgba(50, 143, 151, 0.4);
-  text-decoration-thickness: 1px;
-  text-underline-offset: 2px;
-}
-
-a:hover {
-  color: #246f76;
-}
-
-code {
-  font-size: 0.9em;
-  border: 1px solid var(--line);
-  background: color-mix(in oklab, var(--surface-strong) 82%, white 18%);
-  border-radius: 7px;
-  padding: 2px 7px;
-}
-
-pre code {
-  border: 0;
-  background: transparent;
-  padding: 0;
-  border-radius: 0;
-  font-size: inherit;
-  color: inherit;
-}
-
-.page-wrap {
-  width: min(1080px, calc(100% - 2rem));
-  margin-inline: auto;
-}
-
-.display-title {
-  font-family: "Fraunces", Georgia, serif;
-}
-
-.island-shell {
-  border: 1px solid var(--line);
-  background: linear-gradient(165deg, var(--surface-strong), var(--surface));
-  box-shadow:
-    0 1px 0 var(--inset-glint) inset,
-    0 22px 44px rgba(30, 90, 72, 0.1),
-    0 6px 18px rgba(23, 58, 64, 0.08);
-  backdrop-filter: blur(4px);
-}
-
-.feature-card {
-  background: linear-gradient(
-    165deg,
-    color-mix(in oklab, var(--surface-strong) 93%, white 7%),
-    var(--surface)
-  );
-  box-shadow:
-    0 1px 0 var(--inset-glint) inset,
-    0 18px 34px rgba(30, 90, 72, 0.1),
-    0 4px 14px rgba(23, 58, 64, 0.06);
-}
-
-.feature-card:hover {
-  transform: translateY(-2px);
-  border-color: color-mix(in oklab, var(--lagoon-deep) 35%, var(--line));
-}
-
-button,
-.island-shell,
-a {
-  transition:
-    background-color 180ms ease,
-    color 180ms ease,
-    border-color 180ms ease,
-    transform 180ms ease;
-}
-
-.island-kicker {
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  font-weight: 700;
-  font-size: 0.69rem;
-  color: var(--kicker);
-}
-
-.nav-link {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  text-decoration: none;
-  color: var(--sea-ink-soft);
-}
-
-.nav-link::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  bottom: -6px;
-  width: 100%;
-  height: 2px;
-  transform: scaleX(0);
-  transform-origin: left;
-  background: linear-gradient(90deg, var(--lagoon), #7ed3bf);
-  transition: transform 170ms ease;
-}
-
-.nav-link:hover,
-.nav-link.is-active {
-  color: var(--sea-ink);
-}
-
-.nav-link:hover::after,
-.nav-link.is-active::after {
-  transform: scaleX(1);
-}
-
-@media (max-width: 640px) {
-  .nav-link::after {
-    bottom: -4px;
-  }
-}
-
-.site-footer {
-  border-top: 1px solid var(--line);
-  background: color-mix(in oklab, var(--header-bg) 84%, transparent 16%);
-}
-
-.rise-in {
-  animation: rise-in 700ms cubic-bezier(0.16, 1, 0.3, 1) both;
-}
-
-@keyframes rise-in {
-  from {
-    opacity: 0;
-    transform: translateY(12px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+  --card-foreground: oklch(0.2655 0.0994 282.8386);
+  --popover: oklch(0.2636 0.0964 283.3535);
+  --popover-foreground: oklch(1 0 0);
+  --primary: oklch(0.2636 0.0964 283.3535);
+  --primary-foreground: oklch(1 0 0);
+  --secondary: oklch(0.4409 0.268 277.9092);
+  --secondary-foreground: oklch(1 0 0);
+  --muted: oklch(0.9846 0.0017 247.8389);
+  --muted-foreground: oklch(0.551 0.0234 264.3637);
+  --accent: oklch(0.9587 0.0027 286.3496);
+  --accent-foreground: oklch(0.2636 0.0964 283.3535);
+  --destructive: oklch(0.6368 0.2078 25.3313);
+  --destructive-foreground: oklch(1 0 0);
+  --border: oklch(0.2636 0.0964 283.3535);
+  --input: oklch(1 0 0);
+  --ring: oklch(0.2636 0.0964 283.3535);
+  --chart-1: oklch(0.6231 0.188 259.8145);
+  --chart-2: oklch(0.5461 0.2152 262.8809);
+  --chart-3: oklch(0.4882 0.2172 264.3763);
+  --chart-4: oklch(0.4244 0.1809 265.6377);
+  --chart-5: oklch(0.3791 0.1378 265.5222);
+  --sidebar: oklch(0.9846 0.0017 247.8389);
+  --sidebar-foreground: oklch(0.3211 0 0);
+  --sidebar-primary: oklch(0.6231 0.188 259.8145);
+  --sidebar-primary-foreground: oklch(1 0 0);
+  --sidebar-accent: oklch(0.9514 0.025 236.8242);
+  --sidebar-accent-foreground: oklch(0.3791 0.1378 265.5222);
+  --sidebar-border: oklch(0.9276 0.0058 264.5313);
+  --sidebar-ring: oklch(0.6231 0.188 259.8145);
+  --font-sans: Barlow, ui-sans-serif, sans-serif, system-ui;
+  --font-serif: "Montserrat", sans-serif;
+  --font-mono: Source Code Pro, ui-monospace, monospace;
+  --radius: 0.375rem;
+  --shadow-x: 0;
+  --shadow-y: 1px;
+  --shadow-blur: 3px;
+  --shadow-spread: 0px;
+  --shadow-opacity: 0.1;
+  --shadow-color: oklch(0 0 0);
+  --shadow-2xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
+  --shadow-xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
+  --shadow-sm: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 1px 2px -1px hsl(0 0% 0% / 0.1);
+  --shadow: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 1px 2px -1px hsl(0 0% 0% / 0.1);
+  --shadow-md: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 2px 4px -1px hsl(0 0% 0% / 0.1);
+  --shadow-lg: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 4px 6px -1px hsl(0 0% 0% / 0.1);
+  --shadow-xl: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 8px 10px -1px hsl(0 0% 0% / 0.1);
+  --shadow-2xl: 0 1px 3px 0px hsl(0 0% 0% / 0.25);
+  --tracking-normal: 0em;
+  --spacing: 0.25rem;
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.809 0.105 251.813);
-  --chart-2: oklch(0.623 0.214 259.815);
-  --chart-3: oklch(0.546 0.245 262.881);
-  --chart-4: oklch(0.488 0.243 264.376);
-  --chart-5: oklch(0.424 0.199 265.638);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --background: oklch(0.2046 0 0);
+  --foreground: oklch(0.9219 0 0);
+  --card: oklch(0.2686 0 0);
+  --card-foreground: oklch(0.9219 0 0);
+  --popover: oklch(0.2686 0 0);
+  --popover-foreground: oklch(0.9219 0 0);
+  --primary: oklch(0.6231 0.188 259.8145);
+  --primary-foreground: oklch(1 0 0);
+  --secondary: oklch(0.2686 0 0);
+  --secondary-foreground: oklch(0.9219 0 0);
+  --muted: oklch(0.2393 0 0);
+  --muted-foreground: oklch(0.7155 0 0);
+  --accent: oklch(0.3791 0.1378 265.5222);
+  --accent-foreground: oklch(0.8823 0.0571 254.1284);
+  --destructive: oklch(0.6368 0.2078 25.3313);
+  --destructive-foreground: oklch(1 0 0);
+  --border: oklch(0.3715 0 0);
+  --input: oklch(0.3715 0 0);
+  --ring: oklch(0.6231 0.188 259.8145);
+  --chart-1: oklch(0.7137 0.1434 254.624);
+  --chart-2: oklch(0.6231 0.188 259.8145);
+  --chart-3: oklch(0.5461 0.2152 262.8809);
+  --chart-4: oklch(0.4882 0.2172 264.3763);
+  --chart-5: oklch(0.4244 0.1809 265.6377);
+  --sidebar: oklch(0.2046 0 0);
+  --sidebar-foreground: oklch(0.9219 0 0);
+  --sidebar-primary: oklch(0.6231 0.188 259.8145);
+  --sidebar-primary-foreground: oklch(1 0 0);
+  --sidebar-accent: oklch(0.3791 0.1378 265.5222);
+  --sidebar-accent-foreground: oklch(0.8823 0.0571 254.1284);
+  --sidebar-border: oklch(0.3715 0 0);
+  --sidebar-ring: oklch(0.6231 0.188 259.8145);
+  --font-sans: Barlow, ui-sans-serif, sans-serif, system-ui;
+  --font-serif: Source Serif 4, serif;
+  --font-mono: Source Code Pro, ui-monospace, monospace;
+  --radius: 0.375rem;
+  --shadow-x: 0;
+  --shadow-y: 1px;
+  --shadow-blur: 3px;
+  --shadow-spread: 0px;
+  --shadow-opacity: 0.1;
+  --shadow-color: oklch(0 0 0);
+  --shadow-2xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
+  --shadow-xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
+  --shadow-sm: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 1px 2px -1px hsl(0 0% 0% / 0.1);
+  --shadow: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 1px 2px -1px hsl(0 0% 0% / 0.1);
+  --shadow-md: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 2px 4px -1px hsl(0 0% 0% / 0.1);
+  --shadow-lg: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 4px 6px -1px hsl(0 0% 0% / 0.1);
+  --shadow-xl: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 8px 10px -1px hsl(0 0% 0% / 0.1);
+  --shadow-2xl: 0 1px 3px 0px hsl(0 0% 0% / 0.25);
 }
 
 @theme inline {
-  --font-sans: "Inter Variable", sans-serif;
-  --color-sidebar-ring: var(--sidebar-ring);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar: var(--sidebar);
-  --color-chart-5: var(--chart-5);
-  --color-chart-4: var(--chart-4);
-  --color-chart-3: var(--chart-3);
-  --color-chart-2: var(--chart-2);
-  --color-chart-1: var(--chart-1);
-  --color-ring: var(--ring);
-  --color-input: var(--input);
-  --color-border: var(--border);
-  --color-destructive: var(--destructive);
-  --color-accent-foreground: var(--accent-foreground);
-  --color-accent: var(--accent);
-  --color-muted-foreground: var(--muted-foreground);
-  --color-muted: var(--muted);
-  --color-secondary-foreground: var(--secondary-foreground);
-  --color-secondary: var(--secondary);
-  --color-primary-foreground: var(--primary-foreground);
-  --color-primary: var(--primary);
-  --color-popover-foreground: var(--popover-foreground);
-  --color-popover: var(--popover);
-  --color-card-foreground: var(--card-foreground);
-  --color-card: var(--card);
-  --color-foreground: var(--foreground);
   --color-background: var(--background);
-  --radius-sm: calc(var(--radius) * 0.6);
-  --radius-md: calc(var(--radius) * 0.8);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+
+  --font-sans: var(--font-sans);
+  --font-mono: var(--font-mono);
+  --font-serif: var(--font-serif);
+
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) * 1.4);
-  --radius-2xl: calc(var(--radius) * 1.8);
-  --radius-3xl: calc(var(--radius) * 2.2);
-  --radius-4xl: calc(var(--radius) * 2.6);
+  --radius-xl: calc(var(--radius) + 4px);
+
+  --shadow-2xs: var(--shadow-2xs);
+  --shadow-xs: var(--shadow-xs);
+  --shadow-sm: var(--shadow-sm);
+  --shadow: var(--shadow);
+  --shadow-md: var(--shadow-md);
+  --shadow-lg: var(--shadow-lg);
+  --shadow-xl: var(--shadow-xl);
+  --shadow-2xl: var(--shadow-2xl);
 }
 
 @layer base {
@@ -389,8 +170,5 @@ a {
   }
   body {
     @apply bg-background text-foreground;
-  }
-  html {
-    @apply font-sans;
   }
 }


### PR DESCRIPTION
PR attempts to close #36 

# Description
This pr attemps to introduce styling that resemble the visual idendity of aau. https://www.aau.dk/.
I used https://tweakcn.com/editor/theme?tab=typography to build a Shadcn theme based on inspecting the aau website in the browser. I have also used V0 to generate a component for search results as well as a search bar that has a type of either integrated or standalone. Integrated is with the search bar drop down closely resembling google maps.

I have also made additional small changes such as changing the padding of buttons, making the admin login form trigger aria-invalid so the input field becomes red, changed font to aau styled.

# Demo
Go to /ui-demo endpoint to see the different ui components. ui-demo is of coure only a temp endpoint and should not be deployed.

<img width="570" height="839" alt="image" src="https://github.com/user-attachments/assets/ea5af1c9-dd24-4aee-a6e6-0f96dcfebe6d" />
<img width="562" height="419" alt="image" src="https://github.com/user-attachments/assets/482fc0bb-de4e-451b-8940-168a3e7f5e04" />

# Todo
Once ready the search results should of course depend on the rooms from the database and furthermore this current filter function should be using the fuzzy search library. 
```ts
  // Filter results by query for the integrated bar
  const filteredResults = integratedQuery
    ? ALL_RESULTS.filter(
        (r) =>
          r.title.toLowerCase().includes(integratedQuery.toLowerCase()) ||
          r.semantic?.toLowerCase().includes(integratedQuery.toLowerCase()),
      )
    : ALL_RESULTS
