### PR TITLE
Fix/session leaks & docker compose issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
         - action: sync
           path: ./src
           target: /src
-          initial_sync: true
           ignore:
             - node_modules/
         - action: rebuild

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -18,15 +18,28 @@ export const auth = betterAuth({
 
 async function seedAdmin() {
   try {
-    // Delete and recreate to ensure password always matches env
-    await prisma.user.deleteMany({ where: { username: "admin" } })
+    // Delete and recreate to ensure password always matches env.
+    // Use direct Prisma insert instead of signUpEmail to avoid creating a session.
+    const ctx = await auth.$context
+    const hashedPassword = await ctx.password.hash(env.ADMIN_PASSWORD)
+    const userId = crypto.randomUUID()
 
-    await auth.api.signUpEmail({
-      body: {
+    await prisma.user.deleteMany({ where: { username: "admin" } })
+    await prisma.user.create({
+      data: {
+        id: userId,
         email: "admin@admin.local",
-        password: env.ADMIN_PASSWORD,
         name: "Admin",
         username: "admin",
+        emailVerified: true,
+        accounts: {
+          create: {
+            id: crypto.randomUUID(),
+            accountId: userId,
+            providerId: "credential",
+            password: hashedPassword,
+          },
+        },
       },
     })
     console.log("Admin user seeded successfully")


### PR DESCRIPTION
## Description

Fixes an issue when seeding creates a session by default which leaks to the client. The solution is to manually create the user, without session.

## How to run

Clear your DB `npx prisma migrate reset` and inspect upon first visit, you are not signed in.

## Changes made

- Manually create user by seeding through Prisma instead of creating through BetterAuth client.
- Fixed docker compose issue on Windows

## Checklist

- [x] PR title follows the format `Feat/`, `Fix/` or `Chore/` (e.g. `Feat/Add A* pathfinding`)
- [x] Self-assigned this PR
- [x] Added relevant labels (e.g. `feature`, `fix`, `chore`)
- [x] Linked a PBI from GitHub Projects
- [x] Manually tested the features touched by the files changed
- [x] Project builds locally (`pnpm build`)
- [x] No unrelated changes snuck in
