### PR TITLE
chore/fix tool nav

### DIFF
--- a/src/components/map/action-bar/action-bar.tsx
+++ b/src/components/map/action-bar/action-bar.tsx
@@ -26,7 +26,7 @@ interface ActionBarProps {
 export const ActionBar = ({ className }: ActionBarProps) => {
   const { activeTool, drawing, setActiveTool } = useMap()
 
-  if (activeTool === null) return null
+  if (activeTool === "default") return null
 
   const { icon: Icon, activeLabel } = getToolMeta(activeTool)
   const validationError = activeTool === "draw-room" ? drawing.validationError : null
@@ -65,7 +65,7 @@ export const ActionBar = ({ className }: ActionBarProps) => {
           icon={<LogOut className="size-4" />}
           label="Exit mode"
           onClick={() => {
-            setActiveTool(null)
+            setActiveTool("default")
           }}
         />
       </div>

--- a/src/components/map/tool-palette/tool-button.tsx
+++ b/src/components/map/tool-palette/tool-button.tsx
@@ -19,7 +19,14 @@ interface ToolButtonProps {
  * which tool is on and how to leave it. Active styling comes from the
  * `floating` button variant's `aria-pressed:` rules — no className toggling.
  */
-export const ToolButton = ({ icon, label, active, disabled, onClick, isDefault }: ToolButtonProps) => (
+export const ToolButton = ({
+  icon,
+  label,
+  active,
+  disabled,
+  onClick,
+  isDefault,
+}: ToolButtonProps) => (
   <Tooltip>
     <TooltipTrigger
       render={
@@ -43,6 +50,8 @@ export const ToolButton = ({ icon, label, active, disabled, onClick, isDefault }
         </Button>
       }
     />
-    <TooltipContent side="right">{active && !isDefault ? `Exit ${label.toLowerCase()}` : label}</TooltipContent>
+    <TooltipContent side="right">
+      {active && !isDefault ? `Exit ${label.toLowerCase()}` : label}
+    </TooltipContent>
   </Tooltip>
 )

--- a/src/components/map/tool-palette/tool-button.tsx
+++ b/src/components/map/tool-palette/tool-button.tsx
@@ -9,6 +9,7 @@ interface ToolButtonProps {
   active?: boolean
   disabled?: boolean
   onClick: () => void
+  isDefault?: boolean
 }
 
 /**
@@ -18,7 +19,7 @@ interface ToolButtonProps {
  * which tool is on and how to leave it. Active styling comes from the
  * `floating` button variant's `aria-pressed:` rules — no className toggling.
  */
-export const ToolButton = ({ icon, label, active, disabled, onClick }: ToolButtonProps) => (
+export const ToolButton = ({ icon, label, active, disabled, onClick, isDefault }: ToolButtonProps) => (
   <Tooltip>
     <TooltipTrigger
       render={
@@ -42,6 +43,6 @@ export const ToolButton = ({ icon, label, active, disabled, onClick }: ToolButto
         </Button>
       }
     />
-    <TooltipContent side="right">{active ? `Exit ${label.toLowerCase()}` : label}</TooltipContent>
+    <TooltipContent side="right">{active && !isDefault ? `Exit ${label.toLowerCase()}` : label}</TooltipContent>
   </Tooltip>
 )

--- a/src/components/map/tool-palette/tool-palette.tsx
+++ b/src/components/map/tool-palette/tool-palette.tsx
@@ -15,12 +15,13 @@ interface ToolPaletteProps {
  * (e.g. `connect-edge`) that aren't wired yet — drop an id in here once its
  * implementation lands.
  */
-const VISIBLE_TOOLS: ToolId[] = ["draw-room", "edit-room", "draw-node"]
+const VISIBLE_TOOLS: ToolId[] = ["default", "draw-room", "edit-room", "draw-node"]
 
 /**
  * Vertical tool palette on the left edge of the map. Exactly one tool can be
- * active at a time; clicking the active tool deactivates it. Contextual
- * actions for the active tool live in the `ActionBar` at the bottom-center.
+ * active at a time; clicking the active tool reverts to the default tool.
+ * Contextual actions for the active tool live in the `ActionBar` at the
+ * bottom-center.
  */
 export const ToolPalette = ({ className }: ToolPaletteProps) => {
   const { activeTool, setActiveTool } = useMap()
@@ -35,14 +36,17 @@ export const ToolPalette = ({ className }: ToolPaletteProps) => {
     >
       {visibleTools.map((tool) => {
         const Icon = tool.icon
+        const isActive = activeTool === tool.id
+        const displayLabel = isActive && tool.id === "default" ? tool.activeLabel : tool.label
         return (
           <ToolButton
             key={tool.id}
             icon={<Icon className="size-6 text-white" />}
-            label={tool.label}
-            active={activeTool === tool.id}
+            label={displayLabel}
+            active={isActive}
+            isDefault={tool.id === "default"}
             onClick={() => {
-              setActiveTool(activeTool === tool.id ? null : tool.id)
+              setActiveTool(isActive ? "default" : tool.id)
             }}
           />
         )

--- a/src/components/map/user-tools/render-mode-toggle.tsx
+++ b/src/components/map/user-tools/render-mode-toggle.tsx
@@ -8,7 +8,7 @@ interface RenderModeToggleProps {
 
 export const RenderModeToggle = ({ className }: RenderModeToggleProps) => {
   const { renderMode, setRenderMode, activeTool, isSelectingFloor } = useMap()
-  const locked = activeTool !== null
+  const locked = activeTool !== "default"
 
   if (isSelectingFloor) return null
 

--- a/src/components/threeJS/map-scene.tsx
+++ b/src/components/threeJS/map-scene.tsx
@@ -18,7 +18,7 @@ const GRID_TOOLS = new Set(["draw-room", "draw-node", "connect-edge"])
 
 export const MapScene = () => {
   const { floors, currentFloor, renderMode, activeTool, controlsRef, debugMode } = useMap()
-  const showGrid = debugMode || (activeTool !== null && GRID_TOOLS.has(activeTool))
+  const showGrid = debugMode || (activeTool !== "default" && GRID_TOOLS.has(activeTool))
   const activeFloorPlan = floors.find((f) => f.floor === currentFloor) ?? null
   const neighbourOpacityRef = useRef(0)
 
@@ -36,7 +36,7 @@ export const MapScene = () => {
       style={{
         width: "100%",
         height: "100%",
-        cursor: activeTool === null ? "default" : "crosshair",
+        cursor: activeTool === "default" ? "default" : "crosshair",
       }}
       orthographic={renderMode === "2d"}
     >

--- a/src/components/threeJS/room-polygons-layer.tsx
+++ b/src/components/threeJS/room-polygons-layer.tsx
@@ -209,7 +209,7 @@ export const RoomPolygonsLayer = ({ neighbourOpacityRef }: RoomPolygonsLayerProp
   }, [rooms, renderMode, currentFloor])
 
   const isEditing = activeTool === "edit-room"
-  const isIdle = activeTool === null
+  const isIdle = activeTool === "default"
   const roomsAreClickable = isEditing || isIdle
 
   const handleSelect = (id: string) => {

--- a/src/lib/map-context.tsx
+++ b/src/lib/map-context.tsx
@@ -20,7 +20,7 @@ type RenderMode = "2d" | "3d"
  * are reserved for the next PBI (node + edge editing) so the union doesn't
  * have to change again.
  */
-export type ActiveTool = "draw-room" | "edit-room" | "draw-node" | "connect-edge" | null
+export type ActiveTool = "default" | "draw-room" | "edit-room" | "draw-node" | "connect-edge"
 
 interface MapContextValue {
   floors: FloorPlan[]
@@ -109,7 +109,7 @@ export const MapProvider = ({ children }: { children: ReactNode }) => {
 
   const [debugMode, setDebugMode] = useState(false)
   const [snapToGrid, setSnapToGrid] = useState(false)
-  const [activeTool, setActiveTool] = useState<ActiveTool>(null)
+  const [activeTool, setActiveTool] = useState<ActiveTool>("default")
   const [editingRoomId, setEditingRoomId] = useState<string | null>(null)
   const [viewingRoomId, setViewingRoomId] = useState<string | null>(null)
   const previousRenderModeRef = useRef<RenderMode | null>(null)
@@ -121,12 +121,12 @@ export const MapProvider = ({ children }: { children: ReactNode }) => {
   const handleSetActiveTool = useCallback(
     (tool: ActiveTool) => {
       setActiveTool((current) => {
-        if (current === null && tool !== null) {
+        if (current === "default" && tool !== "default") {
           // Activating: remember the current mode and lock to 2D for vertex placement.
           previousRenderModeRef.current = renderMode
           setRenderMode("2d")
-        } else if (current !== null && tool === null) {
-          // Deactivating: restore the remembered mode (if any).
+        } else if (current !== "default" && tool === "default") {
+          // Returning to the default view: restore the remembered mode.
           const previous = previousRenderModeRef.current
           previousRenderModeRef.current = null
           if (previous !== null) {

--- a/src/lib/tool-registry.ts
+++ b/src/lib/tool-registry.ts
@@ -1,4 +1,4 @@
-import { MousePointer2, Pencil, Waypoints } from "lucide-react"
+import { SquareMousePointer, MousePointer2, Pencil, Waypoints } from "lucide-react"
 
 import type { ActiveTool } from "#/lib/map-context"
 import type { LucideIcon } from "lucide-react"
@@ -21,8 +21,9 @@ export interface ToolMeta {
  * new tool = add an entry here, implement its actions component, done.
  */
 export const TOOL_REGISTRY: ToolMeta[] = [
+  { id: "default", label: "Map view", activeLabel: "Viewing map", icon: MousePointer2 },
   { id: "draw-room", label: "Draw room", activeLabel: "Drawing room", icon: Pencil },
-  { id: "edit-room", label: "Edit rooms", activeLabel: "Editing rooms", icon: MousePointer2 },
+  { id: "edit-room", label: "Edit rooms", activeLabel: "Editing rooms", icon: SquareMousePointer },
   { id: "draw-node", label: "Edit nodes", activeLabel: "Editing nodes", icon: Waypoints },
   {
     id: "connect-edge",
@@ -31,7 +32,6 @@ export const TOOL_REGISTRY: ToolMeta[] = [
     icon: Waypoints,
   },
 ]
-
 const toolById = new Map(TOOL_REGISTRY.map((t) => [t.id, t]))
 
 export const getToolMeta = (id: ToolId): ToolMeta => {


### PR DESCRIPTION
## Description

Introduces a default tool in the tool registry, which represents the base map viewing/showcase state when no other tool is selected and enforces that one mode is always active when the admin is logged in.

Closes #81 

## How to run/see

Log in to the application

## Changes made

Added default tool to tool registry (map viewing/showcase mode)
Enforced that one tool is always active when logged in
Updated tool navigation behavior to prevent having no active tool

## UI changes (Screenshots)
<img width="129" height="328" alt="image" src="https://github.com/user-attachments/assets/bcfa73c3-80c6-441d-ad8e-1d99315fb26f" />


## Checklist

- [x] PR title follows the format `Feat/`, `Fix/` or `Chore/` (e.g. `Feat/Add A* pathfinding`)
- [x] Self-assigned this PR
- [x] Added relevant labels (e.g. `feature`, `fix`, `chore`)
- [x] Linked a PBI from GitHub Projects
- [x] Manually tested the features touched by the files changed
- [x] Project builds locally (`pnpm build`)
- [x] No unrelated changes snuck in
