### PR TITLE
feat/floor plans for deployment

### DIFF
--- a/docker-compose-deploy.yaml
+++ b/docker-compose-deploy.yaml
@@ -36,6 +36,8 @@ services:
       - "traefik.http.routers.${TRAEFIK_SERVICE}-https.service=${TRAEFIK_SERVICE}"
     networks:
       - navNet
+    volumes:
+      - floorplans:/server/.output/public/floorplans
     depends_on:
       postgres:
         condition: service_started
@@ -58,6 +60,8 @@ services:
 
 volumes:
   postgres-data:
+    driver: local
+  floorplans:
     driver: local
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      target: development
+      target: production
       network: host
     develop:
       watch:
@@ -16,7 +16,7 @@ services:
         - action: rebuild
           path: package.json
     ports:
-      - "3001:3000"
+      - "3000:3000"
     environment:
       - NODE_ENV=production
     env_file:

--- a/src/server/import-floor.functions.ts
+++ b/src/server/import-floor.functions.ts
@@ -25,7 +25,10 @@ export const uploadImage = createServerFn({ method: "POST" })
 export const getFloorImage = createServerFn({ method: "GET" })
   .inputValidator(getFloorImageSchema)
   .handler(async ({ data }) => {
-    const uploadDir = path.join(process.cwd(), "public", "floorplans")
+    const uploadDir =
+      process.env.NODE_ENV === "production"
+        ? path.join(process.cwd(), ".output", "public", "floorplans")
+        : path.join(process.cwd(), "public", "floorplans")
 
     let files: string[]
     try {

--- a/src/server/import-floor.server.ts
+++ b/src/server/import-floor.server.ts
@@ -8,7 +8,10 @@ export const saveImageToServer = async (
   filename: string,
   floor: string,
 ): Promise<{ filepath: string }> => {
-  const uploadDir = path.join(process.cwd(), "public", "floorplans")
+  const uploadDir =
+    process.env.NODE_ENV === "production"
+      ? path.join(process.cwd(), ".output", "public", "floorplans")
+      : path.join(process.cwd(), "public", "floorplans")
 
   await fs.mkdir(uploadDir, { recursive: true })
 


### PR DESCRIPTION
## Description

This is a hack and floor plans should never be baked into a project like this IRL.

Using Prisma seed is currently also destructive (`deleteMany`) and also bad practice for production containers.

Also bad to run since it requires bundling more dev dependencies into the container in order to invoke Prisma CLI.

## How to run

Won't work for production builds locally

## Changes made

- Added conditional check for floorplan location at dev time vs build time output in `.output` from Nitro
- Fixed Docker Compose to persist uploads in volume
- 
## UI changes (Screenshots)

N/A

## Checklist

- [x] PR title follows the format `Feat/`, `Fix/` or `Chore/` (e.g. `Feat/Add A* pathfinding`)
- [x] Self-assigned this PR
- [x] Added relevant labels (e.g. `feature`, `fix`, `chore`)
- [ ] Linked a PBI from GitHub Projects
- [x] Manually tested the features touched by the files changed
- [x] Project builds locally (`pnpm build`)
- [x] No unrelated changes snuck in
