### PR TITLE
Update drawing-layer.tsx

### DIFF
--- a/src/components/threeJS/drawing-layer.tsx
+++ b/src/components/threeJS/drawing-layer.tsx
@@ -204,9 +204,9 @@ export const DrawingLayer = ({ floor }: DrawingLayerProps) => {
     <>
       <RaycastPlane floor={floor} {...handlers} />
 
-      {externalCorners.map((corner) => (
+      {externalCorners.map((corner, index) => (
         <VertexMarker
-          key={String(corner.x) + "-" + String(corner.z)}
+          key={String(corner.x) + "-" + String(corner.z) + "-" + String(index)}
           position={lift(corner)}
           color={EXTERNAL_CORNER_COLOR}
           radius={EXTERNAL_CORNER_RADIUS}
@@ -226,9 +226,9 @@ export const DrawingLayer = ({ floor }: DrawingLayerProps) => {
         <EdgePreview points={previewPoints} color={polylineColor} lineWidth={PREVIEW_WIDTH} />
       )}
 
-      {vertices.map((v) => (
+      {vertices.map((v, index) => (
         <VertexMarker
-          key={String(v.x) + "-" + String(v.y) + "-" + String(v.z)}
+          key={String(v.x) + "-" + String(v.y) + "-" + String(v.z) + "-" + String(index)}
           position={lift(v)}
           color={validationError === null ? VERTEX_COLOR : INVALID_COLOR}
           radius={VERTEX_RADIUS}


### PR DESCRIPTION
## Description
Prisma was having issues with polygons not having unique ID's, and warned that this could cause weird duplication or loss of data in the future. Made a small fix to make the ID's unique

<!-- What does this PR do and why? Link the PBI from GitHub Projects below. -->
<!-- If this PR introduces something non-obvious to test, briefly describe how to reach/trigger it. -->

## Changes made
- Changed drawing-layer.tsx to make sure that rooms have unique ID's, which was not the case before because the key was coordinate-based. This makes sure that all rooms are stored correctly and uniquely even when edges overlap.

<!-- If this PR includes visual changes, add screenshots or recordings here. Delete this section if not applicable. -->

## Checklist

- [x] PR title follows the format `Feat/`, `Fix/` or `Chore/` (e.g. `Feat/Add A* pathfinding`)
- [x] Self-assigned this PR
- [x] Added relevant labels (e.g. `feature`, `fix`, `chore`)
- [ ] Linked a PBI from GitHub Projects
- [x] Manually tested the features touched by the files changed
- [x] Project builds locally (`pnpm build`)
- [x] No unrelated changes snuck in
