### PR TITLE
fixed: rooms now linkes to nodes when created

### DIFF
--- a/src/server/graph.server.ts
+++ b/src/server/graph.server.ts
@@ -211,9 +211,19 @@ export const updateNodeInDb = async (
   nodeId: string,
   data: { type: string; x: number; y: number },
 ) => {
+  const roomMatch = await prisma.$queryRaw<{ id: string }[]>`
+    SELECT r.id FROM "Room" r
+    JOIN "Node" n ON n.id = ${nodeId}
+    WHERE r.floor = n.floor
+      AND r.polygon IS NOT NULL
+      AND ST_Contains(r.polygon, ST_MakePoint(${data.x}, ${-data.y}))
+    LIMIT 1
+  `
+  const roomId = roomMatch[0]?.id ?? null
+
   const updated = await prisma.node.update({
     where: { id: nodeId },
-    data: { type: data.type as Node["type"], x: data.x, y: data.y },
+    data: { type: data.type as Node["type"], x: data.x, y: data.y, roomId },
   })
   const g = await getGraph()
   const node = g.nodes.get(nodeId)

--- a/src/server/room.server.ts
+++ b/src/server/room.server.ts
@@ -138,7 +138,7 @@ export const createRoom = async (input: CreateRoomInput): Promise<{ id: string }
   UPDATE "Node"
   SET "roomId" = ${id},
       "updatedAt" = NOW()
-  WHERE floor = ${floor}
+  WHERE "floor" = ${floor}
     AND "roomId" IS NULL
     AND ST_Contains(
       ST_GeomFromText(${wkt}, 0),

--- a/src/server/room.server.ts
+++ b/src/server/room.server.ts
@@ -134,7 +134,17 @@ export const createRoom = async (input: CreateRoomInput): Promise<{ id: string }
       NOW()
     )
   `
-
+  await prisma.$executeRaw`
+  UPDATE "Node"
+  SET "roomId" = ${id},
+      "updatedAt" = NOW()
+  WHERE floor = ${floor}
+    AND "roomId" IS NULL
+    AND ST_Contains(
+      ST_GeomFromText(${wkt}, 0),
+      ST_MakePoint(x, -y)
+    )
+`
   return { id }
 }
 


### PR DESCRIPTION
## Description

When a room was created it did not link the nodes inside it in the db, that is fixed now.

Also fixed bug where, when nodes was updated it did not update the roomId

## Checklist

- [x] PR title follows the format `Feat/`, `Fix/` or `Chore/` (e.g. `Feat/Add A* pathfinding`)
- [x] Self-assigned this PR
- [x] Added relevant labels (e.g. `feature`, `fix`, `chore`)
- [ ] Linked a PBI from GitHub Projects
- [x] Manually tested the features touched by the files changed
- [x] Project builds locally (`pnpm build`)
- [x] No unrelated changes snuck in
