### PR TITLE
Feat/Room overlay toggle

### DIFF
--- a/src/components/map/user-tools/room-overlay-toggle.tsx
+++ b/src/components/map/user-tools/room-overlay-toggle.tsx
@@ -1,0 +1,41 @@
+import { Eye, EyeOff } from "lucide-react"
+
+import { Button } from "#/components/ui/button"
+import { Tooltip, TooltipContent, TooltipTrigger } from "#/components/ui/tooltip"
+import { useMap } from "#/lib/map-context"
+
+interface RoomOverlayToggleProps {
+  className?: string
+}
+
+export const RoomOverlayToggle = ({ className }: RoomOverlayToggleProps) => {
+  const { roomOverlayMode, setRoomOverlayMode, isSelectingFloor } = useMap()
+  const isHidden = roomOverlayMode === "none"
+
+  if (isSelectingFloor) return null
+
+  const tooltipLabel = isHidden ? "Show room icons" : "Hide room overlays"
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            variant="floating"
+            size="icon-xl"
+            type="button"
+            aria-pressed={!isHidden}
+            aria-label={tooltipLabel}
+            className={className}
+            onClick={() => {
+              setRoomOverlayMode(isHidden ? "icon" : "none")
+            }}
+          >
+            {isHidden ? <EyeOff className="size-5" /> : <Eye className="size-5" />}
+          </Button>
+        }
+      />
+      <TooltipContent side="left">{tooltipLabel}</TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/components/threeJS/room-polygons-layer.tsx
+++ b/src/components/threeJS/room-polygons-layer.tsx
@@ -152,8 +152,7 @@ const RoomPolygon = ({
       if ((camera as THREE.OrthographicCamera).isOrthographicCamera) {
         shouldShowIcon = (camera as THREE.OrthographicCamera).zoom >= ICON_HIDE_ZOOM_THRESHOLD_2D
       } else {
-        shouldShowIcon =
-          camera.position.distanceTo(iconPosition) <= ICON_HIDE_DISTANCE_THRESHOLD_3D
+        shouldShowIcon = camera.position.distanceTo(iconPosition) <= ICON_HIDE_DISTANCE_THRESHOLD_3D
       }
     }
 

--- a/src/components/threeJS/room-polygons-layer.tsx
+++ b/src/components/threeJS/room-polygons-layer.tsx
@@ -92,11 +92,13 @@ const RoomPolygon = ({
   onSelect,
   neighbourOpacityRef,
 }: RoomPolygonProps) => {
+  const { roomOverlayMode } = useMap()
   const meshRef = useRef<THREE.Mesh>(null)
   const materialRef = useRef<THREE.MeshBasicMaterial>(null)
 
   const geometry = useMemo(() => buildPolygonGeometry(room.vertices), [room.vertices])
   const fillColor = useMemo(() => getRoomTypeMeta(room.type).color, [room.type])
+  const TypeIcon = useMemo(() => getRoomTypeMeta(room.type).icon, [room.type])
   const outlineColor = useMemo(() => getRoomTypeOutline(room.type), [room.type])
   const centroid = useMemo(() => computeCentroid(room.vertices), [room.vertices])
 
@@ -156,10 +158,10 @@ const RoomPolygon = ({
         />
       </mesh>
       <EdgePreview points={outlinePoints} color={outlineColor} lineWidth={OUTLINE_WIDTH} closed />
-      {active && (
+      {active && roomOverlayMode === "icon" && (
         <Html position={[centroid.x, yOutline, centroid.z]} center zIndexRange={[0, 0]}>
-          <div className="pointer-events-none rounded bg-black/60 px-1.5 py-0.5 text-xs font-semibold text-white whitespace-nowrap">
-            {room.displayName || room.type.replace("_", " ")}
+          <div className="pointer-events-none rounded-full bg-black/60 p-1.5 text-white">
+            <TypeIcon className="size-4" />
           </div>
         </Html>
       )}

--- a/src/components/threeJS/room-polygons-layer.tsx
+++ b/src/components/threeJS/room-polygons-layer.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable react/no-unknown-property */
 import { Html } from "@react-three/drei"
-import { useFrame } from "@react-three/fiber"
+import { useFrame, useThree } from "@react-three/fiber"
 import { useQuery } from "@tanstack/react-query"
-import { useCallback, useMemo, useRef } from "react"
+import { useCallback, useMemo, useRef, useState } from "react"
 import * as THREE from "three"
 
 import { useMap } from "#/lib/map-context"
@@ -21,6 +21,8 @@ const SELECTED_FILL_OPACITY = 0.8
 const OUTLINE_WIDTH = 5
 /** Tiny extra Y offset above DRAWING_LIFT for the outline so it doesn't z-fight the fill mesh. */
 const OUTLINE_LIFT = 0.002
+const ICON_HIDE_ZOOM_THRESHOLD_2D = 10.5
+const ICON_HIDE_DISTANCE_THRESHOLD_3D = 45
 /**
  * Render after FloorPlane (which sets renderOrder=1 on the active floor).
  * Without this, the floor texture paints over the polygon fill because
@@ -93,8 +95,11 @@ const RoomPolygon = ({
   neighbourOpacityRef,
 }: RoomPolygonProps) => {
   const { roomOverlayMode } = useMap()
+  const { camera } = useThree()
   const meshRef = useRef<THREE.Mesh>(null)
   const materialRef = useRef<THREE.MeshBasicMaterial>(null)
+  const [iconVisible, setIconVisible] = useState(true)
+  const iconVisibleRef = useRef(true)
 
   const geometry = useMemo(() => buildPolygonGeometry(room.vertices), [room.vertices])
   const fillColor = useMemo(() => getRoomTypeMeta(room.type).color, [room.type])
@@ -104,6 +109,10 @@ const RoomPolygon = ({
 
   const yFill = room.floor * FLOOR_HEIGHT + DRAWING_LIFT
   const yOutline = yFill + OUTLINE_LIFT
+  const iconPosition = useMemo(
+    () => new THREE.Vector3(centroid.x, yOutline, centroid.z),
+    [centroid.x, centroid.z, yOutline],
+  )
 
   // Outline points (open ring) projected to 3D at the outline Y level.
   const outlinePoints = useMemo<[number, number, number][]>(
@@ -137,6 +146,21 @@ const RoomPolygon = ({
       material.opacity = fade * baseOpacity
       mesh.visible = fade > 0.01
     }
+
+    let shouldShowIcon = roomOverlayMode === "icon" && active
+    if (shouldShowIcon) {
+      if ((camera as THREE.OrthographicCamera).isOrthographicCamera) {
+        shouldShowIcon = (camera as THREE.OrthographicCamera).zoom >= ICON_HIDE_ZOOM_THRESHOLD_2D
+      } else {
+        shouldShowIcon =
+          camera.position.distanceTo(iconPosition) <= ICON_HIDE_DISTANCE_THRESHOLD_3D
+      }
+    }
+
+    if (shouldShowIcon !== iconVisibleRef.current) {
+      iconVisibleRef.current = shouldShowIcon
+      setIconVisible(shouldShowIcon)
+    }
   })
 
   return (
@@ -158,7 +182,7 @@ const RoomPolygon = ({
         />
       </mesh>
       <EdgePreview points={outlinePoints} color={outlineColor} lineWidth={OUTLINE_WIDTH} closed />
-      {active && roomOverlayMode === "icon" && (
+      {active && roomOverlayMode === "icon" && iconVisible && (
         <Html position={[centroid.x, yOutline, centroid.z]} center zIndexRange={[0, 0]}>
           <div className="pointer-events-none rounded-full bg-black/60 p-1.5 text-white">
             <TypeIcon className="size-4" />

--- a/src/lib/map-context.tsx
+++ b/src/lib/map-context.tsx
@@ -13,6 +13,7 @@ export type OrbitControlsHandle = ComponentRef<typeof DreiOrbitControls>
 
 type RenderMode = "2d" | "3d"
 type RoomDrawMode = "polygon" | "rectangle"
+type RoomOverlayMode = "icon" | "none"
 
 /**
  * The currently active map-editing tool, or null if none.
@@ -94,6 +95,8 @@ interface MapContextValue {
   setSnapToGrid: (snap: boolean) => void
   roomDrawMode: RoomDrawMode
   setRoomDrawMode: (mode: RoomDrawMode) => void
+  roomOverlayMode: RoomOverlayMode
+  setRoomOverlayMode: (mode: RoomOverlayMode) => void
   /**
    * Current grid spacing in world units, written every frame by the adaptive
    * grid. Ref (not state) so the per-frame writes don't re-render consumers.
@@ -134,6 +137,7 @@ export const MapProvider = ({ children }: { children: ReactNode }) => {
   const [debugMode, setDebugMode] = useState(false)
   const [snapToGrid, setSnapToGrid] = useState(false)
   const [roomDrawMode, setRoomDrawMode] = useState<RoomDrawMode>("polygon")
+  const [roomOverlayMode, setRoomOverlayMode] = useState<RoomOverlayMode>("icon")
   const [activeTool, setActiveTool] = useState<ActiveTool>("default")
   const [editingRoomId, setEditingRoomId] = useState<string | null>(null)
   const [viewingRoomId, setViewingRoomId] = useState<string | null>(null)
@@ -218,6 +222,8 @@ export const MapProvider = ({ children }: { children: ReactNode }) => {
       setSnapToGrid,
       roomDrawMode,
       setRoomDrawMode,
+      roomOverlayMode,
+      setRoomOverlayMode,
       gridSpacingRef,
       controlsRef,
       editingNodeId,
@@ -253,6 +259,7 @@ export const MapProvider = ({ children }: { children: ReactNode }) => {
       editingEdgeId,
       snapToGrid,
       roomDrawMode,
+      roomOverlayMode,
     ],
   )
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -7,6 +7,7 @@ import { Compass } from "#/components/map/user-tools/compass"
 import { DebugToggle } from "#/components/map/user-tools/debug-toggle"
 import { FloorSelector } from "#/components/map/user-tools/floor-selector"
 import { RenderModeToggle } from "#/components/map/user-tools/render-mode-toggle"
+import { RoomOverlayToggle } from "#/components/map/user-tools/room-overlay-toggle"
 import { EdgeMetadataPanel } from "#/components/panels/edge-metadata-panel"
 import { NodeMetadataPanel } from "#/components/panels/node-metadata-panel"
 import { RoomInfoPanel } from "#/components/panels/room-info-panel"
@@ -45,6 +46,7 @@ const App = () => {
           <RoomInfoPanel />
           <div className="absolute flex flex-col gap-2 bottom-6 right-6 z-10">
             {isLoggedIn && <DebugToggle />}
+            <RoomOverlayToggle />
             <RenderModeToggle />
             <Compass />
             <FloorSelector />


### PR DESCRIPTION
Made the overlay for rooms show the icons instead of the all caps category name. Also made a toggle for room overlays, such that you can choose whether to have Icons visible.

## Description
Performance drops when you add many rooms, also the visual aspect of having all the category names was very cluttered, so I made changes so that you can remove the overlay completely with a toggle, in hopes that it might help a bit. I also changed it to be the category icons instead of the All caps category names that it was before.

<!-- What does this PR do and why? Link the PBI from GitHub Projects below. -->

<!-- If this PR introduces something non-obvious to test, briefly describe how to reach/trigger it. -->

## Changes made

- Added a toggle for room overlay
- Changed the room overlay to be icons instead of category names


## UI changes (Screenshots)

<!-- If this PR includes visual changes, add screenshots or recordings here. Delete this section if not applicable. -->
With icons:
<img width="1628" height="778" alt="image" src="https://github.com/user-attachments/assets/b3527343-f37a-42c1-a223-f3021a423c80" />
Without anything:
<img width="1635" height="800" alt="image" src="https://github.com/user-attachments/assets/958717eb-b400-4f1a-80cf-373fc67547f4" />
Toggle:
<img width="122" height="285" alt="image" src="https://github.com/user-attachments/assets/ea6bd5c1-0835-4de0-aae1-18c20be94926" />
<img width="126" height="291" alt="image" src="https://github.com/user-attachments/assets/9c748a02-ee5a-476a-8e30-97586c6813e5" />



## Checklist

- [x] PR title follows the format `Feat/`, `Fix/` or `Chore/` (e.g. `Feat/Add A* pathfinding`)
- [x] Self-assigned this PR
- [x] Added relevant labels (e.g. `feature`, `fix`, `chore`)
- [ ] Linked a PBI from GitHub Projects
- [x] Manually tested the features touched by the files changed
- [x] Project builds locally (`pnpm build`)
- [x] No unrelated changes snuck in
