### PR TITLE
Fix/drag controls

### DIFF
--- a/src/components/hooks/use-canvas-pointer.ts
+++ b/src/components/hooks/use-canvas-pointer.ts
@@ -5,7 +5,9 @@ import type { ThreeEvent } from "@react-three/fiber"
 import type * as THREE from "three"
 
 /** Pointer-move distance (px) above which a press-release is treated as a drag, not a click. */
-const DRAG_THRESHOLD_PX = 5
+const DRAG_THRESHOLD_PX_MOUSE = 5
+/** Touch input jitters more than mouse, so the threshold needs to be more forgiving on mobile. */
+const DRAG_THRESHOLD_PX_TOUCH = 12
 
 interface UseCanvasPointerOptions {
   /** Fires on a click that is not part of a camera drag. Receives the world-space hit point. */
@@ -36,7 +38,7 @@ export const useCanvasPointer = ({
   onMove,
   enabled = true,
 }: UseCanvasPointerOptions): CanvasPointerHandlers => {
-  const downPos = useRef<{ x: number; y: number } | null>(null)
+  const downPos = useRef<{ x: number; y: number; pointerType: string } | null>(null)
 
   return useMemo<CanvasPointerHandlers>(() => {
     if (!enabled) {
@@ -45,7 +47,7 @@ export const useCanvasPointer = ({
 
     const handlers: CanvasPointerHandlers = {
       onPointerDown: (e) => {
-        downPos.current = { x: e.clientX, y: e.clientY }
+        downPos.current = { x: e.clientX, y: e.clientY, pointerType: e.pointerType }
       },
       onPointerUp: (e) => {
         const start = downPos.current
@@ -53,7 +55,9 @@ export const useCanvasPointer = ({
         if (!start) return
         const dx = e.clientX - start.x
         const dy = e.clientY - start.y
-        if (Math.hypot(dx, dy) > DRAG_THRESHOLD_PX) return
+        const threshold =
+          start.pointerType === "touch" ? DRAG_THRESHOLD_PX_TOUCH : DRAG_THRESHOLD_PX_MOUSE
+        if (Math.hypot(dx, dy) > threshold) return
         onClick(e.point.clone())
       },
     }

--- a/src/components/threeJS/map-scene.tsx
+++ b/src/components/threeJS/map-scene.tsx
@@ -30,6 +30,14 @@ export const MapScene = () => {
     [activeFloor],
   )
 
+  const mouseButtons = useMemo(
+    () => ({
+      LEFT: THREE.MOUSE.PAN,
+      MIDDLE: THREE.MOUSE.DOLLY,
+    }),
+    [],
+  )
+
   return (
     <Canvas
       gl={{ antialias: true }}
@@ -56,7 +64,8 @@ export const MapScene = () => {
         enablePan
         enableZoom
         enableRotate
-        touches={{ ONE: THREE.TOUCH.ROTATE, TWO: THREE.TOUCH.DOLLY_PAN }}
+        mouseButtons={mouseButtons}
+        touches={{ ONE: THREE.TOUCH.PAN, TWO: THREE.TOUCH.DOLLY_ROTATE }}
         minPolarAngle={renderMode === "2d" ? TOP_DOWN_POLAR : 0}
         maxPolarAngle={renderMode === "2d" ? TOP_DOWN_POLAR : MAX_POLAR_ANGLE}
       />


### PR DESCRIPTION
**Depends on:** PR #115 (`Chore/add useIsMobile hook`). Merge that first.

---

## Description

Camera gestures on the map were broken on mobile (no way to pan with one finger) and unintuitive on desktop (left-drag rotated, no shift modifier). This PR brings them in line with Google Maps.

Closes N/A

## How to run

- Desktop: drag with the left mouse button → pans. Hold **Ctrl** + drag → rotates.
- Mobile: drag with one finger → pans. Two-finger gesture → rotates and pinch-zooms.
- Try clicking/tapping a room on mobile - taps now register reliably even with finger jitter.

## Changes made

### OrbitControls (`map-scene.tsx`)
- Left-drag now pans (was rotate). Single-finger touch also pans.
- Shift + left-drag rotates.
- Two-finger touch uses `DOLLY_ROTATE` so pinch zooms and twist rotates simultaneously.
- Right-click no longer rotates.
- Shift state is tracked via `keydown`/`keyup` listeners with a `blur` reset so the modifier doesn't get stuck.

### Touch tap reliability (`use-canvas-pointer.ts`)
- Touch taps commonly jitter 8–15 px even when the user means to tap. The 5 px drag-vs-click threshold misclassified most touch taps as drags, so room/node clicks didn't register on mobile.
- Threshold is now pointer-type aware: 5 px for mouse, 12 px for touch.

## UI changes (Screenshots)

N/A

## Checklist

- [x] PR title follows the format `Feat/`, `Fix/` or `Chore/` (e.g. `Feat/Add A* pathfinding`)
- [x] Self-assigned this PR
- [x] Added relevant labels (e.g. `feature`, `fix`, `chore`)
- [ ] Linked a PBI from GitHub Projects
- [x] Manually tested the features touched by the files changed
- [x] Project builds locally (`pnpm build`)
- [x] No unrelated changes snuck in