### PR TITLE
Chore/add useIsMobile hook

### DIFF
--- a/src/components/hooks/use-is-mobile.ts
+++ b/src/components/hooks/use-is-mobile.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react"
+
+const MOBILE_BREAKPOINT_PX = 768
+const MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT_PX}px)`
+
+/**
+ * Returns whether the viewport is at or below the mobile breakpoint.
+ *
+ * SSR-safe: defaults to false on the server and resolves on first client
+ * render. Updates live as the viewport crosses the breakpoint.
+ */
+export const useIsMobile = (): boolean => {
+  const [isMobile, setIsMobile] = useState(() => {
+    if (typeof globalThis.matchMedia !== "function") return false
+    return globalThis.matchMedia(MOBILE_QUERY).matches
+  })
+
+  useEffect(() => {
+    const mql = globalThis.matchMedia(MOBILE_QUERY)
+    const handleChange = (e: MediaQueryListEvent) => {
+      setIsMobile(e.matches)
+    }
+    setIsMobile(mql.matches)
+    mql.addEventListener("change", handleChange)
+    return () => {
+      mql.removeEventListener("change", handleChange)
+    }
+  }, [])
+
+  return isMobile
+}


### PR DESCRIPTION
**Depends on:** _none — base PR_

---

## Description

Adds a `useIsMobile` hook used by upcoming responsive Panel work. The hook tells consumers whether the viewport is at or below the mobile breakpoint (768 px) and updates live as the viewport crosses it.

Self-contained PR with no consumers yet — the responsive Panel PR depends on it.

Closes N/A

## How to run

This hook isn't consumed yet on `dev`. Smoke check: `pnpm build` succeeds; the file lints; the hook returns a stable boolean during a normal client render.

## Changes made

### `useIsMobile` hook

- Returns a plain `boolean` based on `matchMedia('(max-width: 768px)')`.
- Lazy `useState` initializer reads `matchMedia` synchronously on first client render — no flicker window, so no need for an `isLoading` flag.
- `change` listener on the `MediaQueryList` keeps it in sync as the viewport crosses the breakpoint.
- SSR-safe: guards `matchMedia` so it's a no-op on the server (TanStack Start renders on the server, so unguarded `window` access during render would crash).
- `globalThis` instead of `window` (matches the codebase's SonarQube rule).
- Style matches the rest of the codebase (no semicolons, named export, 2-space indent).

## UI changes (Screenshots)

N/A

## Checklist

- [x] PR title follows the format `Feat/`, `Fix/` or `Chore/` (e.g. `Feat/Add A* pathfinding`)
- [x] Self-assigned this PR
- [x] Added relevant labels (e.g. `feature`, `fix`, `chore`)
- [ ] Linked a PBI from GitHub Projects
- [x] Manually tested the features touched by the files changed
- [x] Project builds locally (`pnpm build`)
- [x] No unrelated changes snuck in