### PR TITLE
Fix/root layout and overlays

### DIFF
--- a/src/components/hooks/use-canvas-pointer.ts
+++ b/src/components/hooks/use-canvas-pointer.ts
@@ -5,7 +5,9 @@ import type { ThreeEvent } from "@react-three/fiber"
 import type * as THREE from "three"
 
 /** Pointer-move distance (px) above which a press-release is treated as a drag, not a click. */
-const DRAG_THRESHOLD_PX = 5
+const DRAG_THRESHOLD_PX_MOUSE = 5
+/** Touch input jitters more than mouse, so the threshold needs to be more forgiving on mobile. */
+const DRAG_THRESHOLD_PX_TOUCH = 12
 
 interface UseCanvasPointerOptions {
   /** Fires on a click that is not part of a camera drag. Receives the world-space hit point. */
@@ -36,7 +38,7 @@ export const useCanvasPointer = ({
   onMove,
   enabled = true,
 }: UseCanvasPointerOptions): CanvasPointerHandlers => {
-  const downPos = useRef<{ x: number; y: number } | null>(null)
+  const downPos = useRef<{ x: number; y: number; pointerType: string } | null>(null)
 
   return useMemo<CanvasPointerHandlers>(() => {
     if (!enabled) {
@@ -45,7 +47,7 @@ export const useCanvasPointer = ({
 
     const handlers: CanvasPointerHandlers = {
       onPointerDown: (e) => {
-        downPos.current = { x: e.clientX, y: e.clientY }
+        downPos.current = { x: e.clientX, y: e.clientY, pointerType: e.pointerType }
       },
       onPointerUp: (e) => {
         const start = downPos.current
@@ -53,7 +55,9 @@ export const useCanvasPointer = ({
         if (!start) return
         const dx = e.clientX - start.x
         const dy = e.clientY - start.y
-        if (Math.hypot(dx, dy) > DRAG_THRESHOLD_PX) return
+        const threshold =
+          start.pointerType === "touch" ? DRAG_THRESHOLD_PX_TOUCH : DRAG_THRESHOLD_PX_MOUSE
+        if (Math.hypot(dx, dy) > threshold) return
         onClick(e.point.clone())
       },
     }

--- a/src/components/hooks/use-is-mobile.ts
+++ b/src/components/hooks/use-is-mobile.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react"
+
+const MOBILE_BREAKPOINT_PX = 768
+const MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT_PX}px)`
+
+/**
+ * Returns whether the viewport is at or below the mobile breakpoint.
+ *
+ * SSR-safe: defaults to false on the server and resolves on first client
+ * render. Updates live as the viewport crosses the breakpoint.
+ */
+export const useIsMobile = (): boolean => {
+  const [isMobile, setIsMobile] = useState(() => {
+    if (typeof globalThis.matchMedia !== "function") return false
+    return globalThis.matchMedia(MOBILE_QUERY).matches
+  })
+
+  useEffect(() => {
+    const mql = globalThis.matchMedia(MOBILE_QUERY)
+    const handleChange = (e: MediaQueryListEvent) => {
+      setIsMobile(e.matches)
+    }
+    setIsMobile(mql.matches)
+    mql.addEventListener("change", handleChange)
+    return () => {
+      mql.removeEventListener("change", handleChange)
+    }
+  }, [])
+
+  return isMobile
+}

--- a/src/components/map/search/fuzzy-search-bar.tsx
+++ b/src/components/map/search/fuzzy-search-bar.tsx
@@ -9,7 +9,7 @@ import type { SearchResultItem } from "#/components/ui/search-result-list"
 
 type SearchResultItemWithDbId = SearchResultItem & { dbId: string }
 
-export const FuzzySearchBar = () => {
+export const FuzzySearchBar = ({ className }: { className?: string }) => {
   const { setViewingRoomId, setEditingRoomId, activeTool } = useMap()
   const [query, setQuery] = useState("")
   const { results, isLoading } = useFuzzySearch(query)
@@ -25,7 +25,7 @@ export const FuzzySearchBar = () => {
           id: r.item.roomNumber,
           icon: <Icon className="w-5 h-5" style={{ color: outline }} />,
           iconBgStyle: { backgroundColor: meta.color, outline: `2px solid ${outline}` },
-          title: r.item.displayName || "",
+          title: r.item.displayName ?? "",
           type: meta.label,
           dbId: r.item.id,
         }
@@ -46,7 +46,7 @@ export const FuzzySearchBar = () => {
 
   return (
     <SearchBar
-      className="absolute top-4 left-4 right-4 w-auto z-10 sm:left-30 sm:right-auto sm:w-90"
+      className={className}
       type="integrated"
       placeholder="Search locations..."
       value={query}

--- a/src/components/threeJS/map-scene.tsx
+++ b/src/components/threeJS/map-scene.tsx
@@ -30,6 +30,14 @@ export const MapScene = () => {
     [activeFloor],
   )
 
+  const mouseButtons = useMemo(
+    () => ({
+      LEFT: THREE.MOUSE.PAN,
+      MIDDLE: THREE.MOUSE.DOLLY,
+    }),
+    [],
+  )
+
   return (
     <Canvas
       gl={{ antialias: true }}
@@ -56,7 +64,8 @@ export const MapScene = () => {
         enablePan
         enableZoom
         enableRotate
-        touches={{ ONE: THREE.TOUCH.ROTATE, TWO: THREE.TOUCH.DOLLY_PAN }}
+        mouseButtons={mouseButtons}
+        touches={{ ONE: THREE.TOUCH.PAN, TWO: THREE.TOUCH.DOLLY_ROTATE }}
         minPolarAngle={renderMode === "2d" ? TOP_DOWN_POLAR : 0}
         maxPolarAngle={renderMode === "2d" ? TOP_DOWN_POLAR : MAX_POLAR_ANGLE}
       />

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Link } from "@tanstack/react-router"
 
+import { useIsMobile } from "#/components/hooks/use-is-mobile"
 import { ActionBar } from "#/components/map/action-bar/action-bar"
 import { FuzzySearchBar } from "#/components/map/search/fuzzy-search-bar"
 import { ToolPalette } from "#/components/map/tool-palette/tool-palette"
@@ -16,45 +17,75 @@ import { MapScene } from "#/components/threeJS/map-scene"
 import { buttonVariants } from "#/components/ui/button"
 import { TooltipProvider } from "#/components/ui/tooltip"
 import { useIsLoggedIn } from "#/lib/auth-hooks"
-import { MapProvider } from "#/lib/map-context"
+import { MapProvider, useMap } from "#/lib/map-context"
 
-const App = () => {
+/**
+ * Layout structure (z-stack from bottom to top):
+ *
+ * 1. `<MapScene>` — the 3D canvas, fills `<main>` exactly. Static base layer.
+ * 2. Overlay layer (z-10) — `pointer-events-none` so the canvas receives drags
+ *    in the gaps; each interactive child opts in with `pointer-events-auto`.
+ * 3. Panels (z-30, inside `<Panel>`) — own their own `position: fixed`,
+ *    responsive shape (right side on desktop, bottom sheet on mobile).
+ *
+ * Admin UI (Manage / ToolPalette / ActionBar / draw+edit panels) is normally
+ * desktop-only, but logged-in admins can toggle Debug on mobile to unlock it
+ * for testing.
+ */
+const Layout = () => {
   const { isLoggedIn, isPending } = useIsLoggedIn()
+  const { debugMode } = useMap()
+  const isMobile = useIsMobile()
+  const isAdmin = !isPending && isLoggedIn
+  const showAdminUI = isAdmin && (!isMobile || debugMode)
 
   return (
-    <TooltipProvider>
-      <MapProvider>
-        <main className="w-screen h-screen overflow-y-hidden">
-          {!isPending &&
-            (isLoggedIn ? (
-              <>
-                <Link
-                  className={`${buttonVariants({ variant: "default" })} absolute top-6 left-130 z-100`}
-                  to="/manage-floor"
-                >
-                  Manage
-                </Link>
-                <ToolPalette className="absolute left-6 top-1/2 -translate-y-1/2 z-10" />
-                <ActionBar className="absolute bottom-6 left-1/2 -translate-x-1/2 z-10" />
-                <RoomMetadataPanel />
-                <NodeMetadataPanel />
-                <EdgeMetadataPanel />
-              </>
-            ) : null)}
-          <FuzzySearchBar />
-          <MapScene />
-          <RoomInfoPanel />
-          <div className="absolute flex flex-col gap-2 bottom-6 right-6 z-10">
-            {isLoggedIn && <DebugToggle />}
-            <RoomOverlayToggle />
-            <RenderModeToggle />
-            <Compass />
-            <FloorSelector />
-          </div>
-        </main>
-      </MapProvider>
-    </TooltipProvider>
+    <main className="relative h-dvh w-full overflow-hidden bg-background">
+      <MapScene />
+
+      <div className="pointer-events-none absolute inset-0 z-10">
+        <FuzzySearchBar className="pointer-events-auto absolute top-4 right-4 left-4 w-auto sm:right-auto sm:left-30 sm:w-90" />
+
+        <div className="pointer-events-auto absolute right-6 bottom-6 flex flex-col gap-2">
+          {isAdmin && <DebugToggle />}
+          <RoomOverlayToggle />
+          <RenderModeToggle />
+          <Compass />
+          <FloorSelector />
+        </div>
+
+        {showAdminUI && (
+          <>
+            <Link
+              to="/manage-floor"
+              className={`${buttonVariants({ variant: "default" })} pointer-events-auto absolute top-6 right-30`}
+            >
+              Manage
+            </Link>
+            <ToolPalette className="pointer-events-auto absolute top-1/2 left-6 -translate-y-1/2" />
+            <ActionBar className="pointer-events-auto absolute bottom-6 left-1/2 -translate-x-1/2" />
+          </>
+        )}
+      </div>
+
+      {showAdminUI && (
+        <>
+          <RoomMetadataPanel />
+          <NodeMetadataPanel />
+          <EdgeMetadataPanel />
+        </>
+      )}
+      <RoomInfoPanel />
+    </main>
   )
 }
+
+const App = () => (
+  <TooltipProvider>
+    <MapProvider>
+      <Layout />
+    </MapProvider>
+  </TooltipProvider>
+)
 
 export const Route = createFileRoute("/")({ component: App })


### PR DESCRIPTION
**Depends on:** PR #110 (`Fix/drag controls`) → PR #115 (`Chore/add useIsMobile hook`). Merge in that order first.

---

## Description

The map's layout root used `w-screen h-screen`. `100vw` includes the area reserved for a vertical scrollbar, so `<main>` ended up wider than the visible viewport — children with `right-X` (search bar, right-side tools) got positioned past the visible right edge. `h-screen` doesn't track mobile URL bars either, so the bottom panel could end up below the visible bottom on iOS.

This PR rewrites the layout root, introduces a single overlay model, and tidies a few hardcoded overlay positions that didn't survive narrow viewports.

Closes N/A

## How to run

- Desktop: resize the window across the `md` breakpoint. Search bar is always pinned within the visible viewport. Tool palette / right-side tools never get clipped.
- Mobile: search bar spans `viewport - 32px`. Manage button (admin) is reachable. Bottom panel sits at the visible bottom, not below the URL bar.
- Drag-pan the canvas in the gaps between overlays — drags pass through the overlay layer.

## Changes made

### Layout root (`routes/index.tsx`)
- `<main>` is now `relative h-dvh w-full overflow-hidden`. `relative` is the single positioning context for every overlay; `h-dvh` tracks the dynamic viewport (mobile URL bar collapse); `overflow-hidden` prevents any child from extending the box.
- Single overlay layer on top of the canvas: `<div className="pointer-events-none absolute inset-0 z-10">`. Each interactive child opts in with `pointer-events-auto`. Drags pass through the gaps to the canvas underneath.
- Admin UI (Manage / ToolPalette / ActionBar / draw + edit panels) is gated `isAdmin && (!isMobile || debugMode)`. Desktop admins always see admin UI; mobile admins can flip Debug to unlock it for testing.
- `Layout` extracted into a child component inside `MapProvider` so it can read `debugMode` from context.
- Manage link moved off its hard-coded `left-130` (520 px from the left, off-screen on narrow viewports) to `top-6 right-30`.

### Search bar (`fuzzy-search-bar.tsx`)
- Positioning moved out of the component — `FuzzySearchBar` now accepts a `className` prop. The route owns the responsive rules:
  - `< 640 px`: full-width minus 16 px each side.
  - `≥ 640 px`: 360 px wide, anchored 120 px from the left.
- `w-auto` added at the base breakpoint so the underlying `SearchBar`'s baked-in `w-full` doesn't override the `left-X right-X` insets.

## UI changes (Screenshots)

<!-- screenshots: TBA — narrow + medium + wide viewport -->

## Checklist

- [x] PR title follows the format `Feat/`, `Fix/` or `Chore/` (e.g. `Feat/Add A* pathfinding`)
- [x] Self-assigned this PR
- [x] Added relevant labels (e.g. `feature`, `fix`, `chore`)
- [ ] Linked a PBI from GitHub Projects
- [x] Manually tested the features touched by the files changed
- [x] Project builds locally (`pnpm build`)
- [x] No unrelated changes snuck in