### PR TITLE
Fix/performance optimizations

### DIFF
--- a/src/components/threeJS/draw-primitives.tsx
+++ b/src/components/threeJS/draw-primitives.tsx
@@ -46,7 +46,7 @@ export const VertexMarker = ({ position, color = "#ffffff", radius = 0.06 }: Ver
 
   return (
     <mesh ref={meshRef} position={pos}>
-      <sphereGeometry args={[radius, 64, 64]} />
+      <sphereGeometry args={[radius, 10, 10]} />
       <meshBasicMaterial color={color} />
     </mesh>
   )

--- a/src/components/threeJS/drawing-layer.tsx
+++ b/src/components/threeJS/drawing-layer.tsx
@@ -33,6 +33,7 @@ const EXTERNAL_CORNER_RADIUS = 0.09
 const CLOSE_TARGET_RADIUS = 0.18
 const POLYLINE_WIDTH = 4
 const PREVIEW_WIDTH = 3
+const EXTERNAL_CORNER_RENDER_RADIUS_MULTIPLIER = 3
 
 /** Lift a world-space point above the floor plane to avoid z-fighting. */
 const lift = (v: THREE.Vector3): [number, number, number] => [v.x, v.y + DRAWING_LIFT, v.z]
@@ -118,6 +119,14 @@ export const DrawingLayer = ({ floor }: DrawingLayerProps) => {
         .flatMap((r) => r.vertices.map((v) => new THREE.Vector3(v.x, floorY, v.z))),
     [allRooms, floor.floor, floorY],
   )
+
+  // Rendering every external corner marker gets expensive on large datasets.
+  // Keep all corners available for snapping, but only draw those near cursor.
+  const visibleExternalCorners = useMemo<THREE.Vector3[]>(() => {
+    if (!cursor) return []
+    const maxDistance = SNAP_RADIUS_METERS * EXTERNAL_CORNER_RENDER_RADIUS_MULTIPLIER
+    return externalCorners.filter((corner) => cursor.distanceTo(corner) <= maxDistance)
+  }, [externalCorners, cursor])
 
   // True once the polygon is closeable: enough vertices placed AND no
   // validation errors. Drives both the click handler and the always-on
@@ -247,7 +256,7 @@ export const DrawingLayer = ({ floor }: DrawingLayerProps) => {
     <>
       <RaycastPlane floor={floor} {...handlers} />
 
-      {externalCorners.map((corner, index) => (
+      {visibleExternalCorners.map((corner, index) => (
         <VertexMarker
           key={String(corner.x) + "-" + String(corner.z) + "-" + String(index)}
           position={lift(corner)}


### PR DESCRIPTION
## Description
Tried optimizing performance further by reducing marker sphere tessellation. This should reduce geometry complexity per marker. Also made room nodes not show up unless the mouse is within a certain radius of the node, while keeping snapping functionality.

<!-- What does this PR do and why? Link the PBI from GitHub Projects below. -->

<!-- If this PR introduces something non-obvious to test, briefly describe how to reach/trigger it. -->

## Changes made

- Added rendering distance for room nodes based on mouse position 
- Changed marker sphere geometry from 64, 64 to 10, 10 

## UI changes (Screenshots)

<!-- If this PR includes visual changes, add screenshots or recordings here. Delete this section if not applicable. -->

## Checklist

- [x] PR title follows the format `Feat/`, `Fix/` or `Chore/` (e.g. `Feat/Add A* pathfinding`)
- [x] Self-assigned this PR
- [x] Added relevant labels (e.g. `feature`, `fix`, `chore`)
- [ ] Linked a PBI from GitHub Projects
- [x] Manually tested the features touched by the files changed
- [x] Project builds locally (`pnpm build`)
- [x] No unrelated changes snuck in
