### PR TITLE
Feat/a star

### DIFF
--- a/src/server/astar.functions.ts
+++ b/src/server/astar.functions.ts
@@ -1,8 +1,10 @@
-import z from "zod"
-import { nodeTypeEnum } from "./graph.functions"
 import { createServerFn } from "@tanstack/react-start"
-import { astar } from "./astar.server"
+import z from "zod"
+
 import { RoomType } from "#/generated/prisma/enums"
+
+import { astar } from "./astar.server"
+import { nodeTypeEnum } from "./graph.functions"
 
 const roomTypeEnum = z.enum(Object.values(RoomType) as [string, ...string[]])
 

--- a/src/server/astar.functions.ts
+++ b/src/server/astar.functions.ts
@@ -1,0 +1,53 @@
+import z from "zod"
+import { nodeTypeEnum } from "./graph.functions"
+import { createServerFn } from "@tanstack/react-start"
+import { astar } from "./astar.server"
+import { RoomType } from "#/generated/prisma/enums"
+
+const roomTypeEnum = z.enum(Object.values(RoomType) as [string, ...string[]])
+
+const nodeSchema = z.object({
+  id: z.string(),
+  x: z.number(),
+  y: z.number(),
+  z: z.number(),
+  type: nodeTypeEnum,
+  isActivated: z.boolean(),
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+  roomId: z.string().nullable(),
+  floor: z.number().int(),
+})
+
+const xyzSchema = z.object({
+  x: z.number(),
+  y: z.number(),
+  z: z.number(),
+})
+
+const roomSchema = z.object({
+  id: z.string(),
+  roomNumber: z.string(),
+  displayName: z.string().nullable(),
+  isActivated: z.boolean(),
+  type: roomTypeEnum,
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+  sectionId: z.string().nullable(),
+  floor: z.number().int(),
+  nodes: z.array(nodeSchema),
+})
+
+export const astarSchema = z.object({
+  profile: z.enum(["ACCESIBLE_ROUTE", "SIMPLE_ROUTE", "FAST_ROUTE"]),
+  dest: roomSchema,
+  start: z.union([xyzSchema, nodeSchema]),
+})
+
+export type AstarInput = z.infer<typeof astarSchema>
+
+export const astarFunction = createServerFn({ method: "GET" })
+  .inputValidator(astarSchema)
+  .handler(async ({ data }) => {
+    return await astar(data.profile, data.dest, data.start)
+  })

--- a/src/server/astar.server.ts
+++ b/src/server/astar.server.ts
@@ -1,6 +1,7 @@
-import type { AstarInput } from "./astar.functions"
-import type { Edge, Node } from "#/generated/prisma/client"
 import { getGraph } from "./graph.server"
+
+import type { Edge, Node } from "#/generated/prisma/client"
+import type { AstarInput } from "./astar.functions"
 
 const TURN_PENALTY = 1
 const TURN_ANGLE_THRESHOLD = 30 // degrees
@@ -26,10 +27,17 @@ const findClosestNode = async (x: number, y: number, z: number): Promise<Node | 
 
 const reconstructPath = (parent: Map<Node, Node>, t: Node): Node[] => {
   const path: Node[] = [t]
-  while (parent.has(t)) {
-    t = parent.get(t)!
-    path.unshift(t)
+  let current = t
+
+  while (parent.has(current)) {
+    const next = parent.get(current)
+
+    if (!next) break
+
+    current = next
+    path.unshift(current)
   }
+
   return path
 }
 
@@ -124,7 +132,8 @@ export const astar = async (
   insertSorted(open, firstNode, heuristic(firstNode, destinationNode, profile))
 
   while (open.length > 0) {
-    const [current] = open.shift()! // node in open with lowest f-value
+    const current = open.shift()?.[0] // node in open with lowest f-value
+    if (!current) break
 
     if (current.id === destinationNode.id) {
       return reconstructPath(parent, current)
@@ -134,7 +143,7 @@ export const astar = async (
 
     graph.getNeighbors(current.id).forEach((edge) => {
       const neighbor = graph.nodes.get(edge.toNodeId)
-      if (!neighbor || !neighbor.isActivated) return
+      if (!neighbor?.isActivated) return
 
       // g′ ← g[n] + w(n, n′)
       const candidateCost = (g.get(current) ?? Infinity) + edge.distance

--- a/src/server/astar.server.ts
+++ b/src/server/astar.server.ts
@@ -1,6 +1,11 @@
 import type { AstarInput } from "./astar.functions"
-import type { Node } from "#/generated/prisma/client"
+import type { Edge, Node } from "#/generated/prisma/client"
 import { getGraph } from "./graph.server"
+
+const TURN_PENALTY = 1
+const TURN_ANGLE_THRESHOLD = 30 // degrees
+
+const graph = await getGraph()
 
 const findClosestNode = async (x: number, y: number, z: number): Promise<Node | null> => {
   const graph = await getGraph()
@@ -19,19 +24,67 @@ const findClosestNode = async (x: number, y: number, z: number): Promise<Node | 
   return closest
 }
 
-const reconstructPath = (
-  parent: Map<string, string>,
-  t: string,
-  nodes: Map<string, Node>,
-): Node[] => {
-  const path: Node[] = [nodes.get(t)!]
+const reconstructPath = (parent: Map<Node, Node>, t: Node): Node[] => {
+  const path: Node[] = [t]
   while (parent.has(t)) {
     t = parent.get(t)!
-    path.unshift(nodes.get(t)!)
+    path.unshift(t)
   }
   return path
 }
 
+const heuristic = (
+  node: Node,
+  target: Node,
+  profile: AstarInput["profile"],
+  previousEdge?: Edge,
+): number => {
+  if (profile === "ACCESIBLE_ROUTE" && node.type === "STAIR" && previousEdge) {
+    const fromNode = graph.nodes.get(previousEdge.fromNodeId)
+    if (fromNode && fromNode.floor !== node.floor) return Infinity
+  }
+
+  let turnPenalty = 0
+
+  if (profile === "SIMPLE_ROUTE" && previousEdge) {
+    const fromNode = graph.nodes.get(previousEdge.fromNodeId)
+    const toNode = graph.nodes.get(previousEdge.toNodeId)
+    if (fromNode && toNode) {
+      const angle =
+        Math.atan2(node.y - fromNode.y, node.x - fromNode.x) -
+        Math.atan2(toNode.y - fromNode.y, toNode.x - fromNode.x)
+      const angleDeg = Math.abs((angle * 180) / Math.PI)
+      turnPenalty = angleDeg > TURN_ANGLE_THRESHOLD ? TURN_PENALTY : 0
+    }
+  }
+
+  return Math.hypot(node.x - target.x, node.y - target.y, node.z - target.z) + turnPenalty
+}
+
+const findDestinationNode = (destRoom: AstarInput["dest"], startNode: Node): Node | null => {
+  const closest = (type: string): Node | null => {
+    let bestNode: Node | null = null
+    let bestDist = Infinity
+    for (const n of destRoom.nodes) {
+      if (n.type !== type) continue
+      const dist = Math.hypot(n.x - startNode.x, n.y - startNode.y, n.z - startNode.z)
+      if (dist < bestDist) {
+        bestDist = dist
+        bestNode = n as Node
+      }
+    }
+    return bestNode
+  }
+
+  return closest("ENDPOINT") ?? closest("DOOR")
+}
+
+const insertSorted = (open: [Node, number][], node: Node, f: number): void => {
+  open.push([node, f])
+  open.sort(([, a], [, b]) => a - b)
+}
+
+// Algorithm based on pseudocode written in the report
 export const astar = async (
   profile: AstarInput["profile"],
   dest: AstarInput["dest"],
@@ -40,10 +93,6 @@ export const astar = async (
   // If start position is a node
   let firstNode: Node
   if ("id" in start) {
-    // If start node is also end node
-    if (start.id === dest.id) {
-      return [start]
-    }
     firstNode = start as Node
   } else {
     // If start position is not a node, find the closest node to the start position
@@ -52,29 +101,74 @@ export const astar = async (
     firstNode = closest
   }
 
+  const destinationNode = findDestinationNode(dest, firstNode)
+  if (!destinationNode) return null
+
+  // If start node is also end node
+  if (firstNode.id === destinationNode.id) return [firstNode]
+
+  // --------------------------------
+  // Start of algorithm
+  // --------------------------------
+
   // open: priority queue ordered by ascending f-value, where f(v) = g[v] + h(v)
-  const open = new Set<string>()
-  const closed = new Set<string>()
+  const open: [Node, number][] = []
+  const closed = new Set<Node>()
   // g: best known cost from start to v, default is infinity
-  const g = new Map<string, number>()
-  const parent = new Map<string, string>()
+  const g = new Map<Node, number>()
+  const parent = new Map<Node, Node>()
 
-  g.set(firstNode.id, 0)
-  open.add(firstNode.id) // insert s with priority h(s)
+  g.set(firstNode, 0)
 
-  let current: Node | null = null
+  // insert s with priority h(s)
+  insertSorted(open, firstNode, heuristic(firstNode, destinationNode, profile))
 
-  const graph = await getGraph()
+  while (open.length > 0) {
+    const [current] = open.shift()! // node in open with lowest f-value
 
-  while (open.size > 0) {
-    const currentId = open.values().next().value as string // node in open with lowest f-value
-    open.delete(currentId)
-    current = graph.nodes.get(currentId) ?? null
-
-    if (current && dest.nodes.some((n) => n.id === current.id)) {
-      return reconstructPath(parent, current.id, graph.nodes)
+    if (current.id === destinationNode.id) {
+      return reconstructPath(parent, current)
     }
 
-    if (current) closed.add(current.id) // add current to closed
+    closed.add(current) // add current to closed
+
+    graph.getNeighbors(current.id).forEach((edge) => {
+      const neighbor = graph.nodes.get(edge.toNodeId)
+      if (!neighbor || !neighbor.isActivated) return
+
+      // g′ ← g[n] + w(n, n′)
+      const candidateCost = (g.get(current) ?? Infinity) + edge.distance
+
+      // case 1: If n′ is new if n′ ∉ closed and n′ ∉ open
+      if (!closed.has(neighbor) && !open.some(([n]) => n.id === neighbor.id)) {
+        g.set(neighbor, candidateCost) // g[n′] ← g′
+        parent.set(neighbor, current) // parent[n′] ← n
+
+        // update n′ priority in open to g′ + h(n′)
+        insertSorted(
+          open,
+          neighbor,
+          candidateCost + heuristic(neighbor, destinationNode, profile, edge),
+        )
+
+        // case 2: cheaper path via n ... else if n′ ∈ open and g′ < g[n′] then
+      } else if (
+        open.some(([n]) => n.id === neighbor.id) &&
+        candidateCost < (g.get(neighbor) ?? Infinity)
+      ) {
+        // g[n′] ← g′
+        g.set(neighbor, candidateCost)
+
+        // parent[n′] ← n
+        parent.set(neighbor, current)
+
+        // update n′ priority in open to g′ + h(n′)
+        const existing = open.findIndex(([n]) => n.id === neighbor.id)
+        if (existing !== -1) open.splice(existing, 1)
+        const h2 = heuristic(neighbor, destinationNode, profile, edge)
+        insertSorted(open, neighbor, candidateCost + h2)
+      }
+    })
   }
+  return null
 }

--- a/src/server/astar.server.ts
+++ b/src/server/astar.server.ts
@@ -1,0 +1,80 @@
+import type { AstarInput } from "./astar.functions"
+import type { Node } from "#/generated/prisma/client"
+import { getGraph } from "./graph.server"
+
+const findClosestNode = async (x: number, y: number, z: number): Promise<Node | null> => {
+  const graph = await getGraph()
+  const candidates = graph.getNodesByFloor(z)
+
+  let closest: Node | null = null
+  let minDist = Infinity
+
+  for (const node of candidates) {
+    const dist = Math.hypot(node.x - x, node.y - y)
+    if (dist < minDist) {
+      minDist = dist
+      closest = node
+    }
+  }
+  return closest
+}
+
+const reconstructPath = (
+  parent: Map<string, string>,
+  t: string,
+  nodes: Map<string, Node>,
+): Node[] => {
+  const path: Node[] = [nodes.get(t)!]
+  while (parent.has(t)) {
+    t = parent.get(t)!
+    path.unshift(nodes.get(t)!)
+  }
+  return path
+}
+
+export const astar = async (
+  profile: AstarInput["profile"],
+  dest: AstarInput["dest"],
+  start: AstarInput["start"],
+) => {
+  // If start position is a node
+  let firstNode: Node
+  if ("id" in start) {
+    // If start node is also end node
+    if (start.id === dest.id) {
+      return [start]
+    }
+    firstNode = start as Node
+  } else {
+    // If start position is not a node, find the closest node to the start position
+    const closest = await findClosestNode(start.x, start.y, start.z)
+    if (!closest) return null
+    firstNode = closest
+  }
+
+  // open: priority queue ordered by ascending f-value, where f(v) = g[v] + h(v)
+  const open = new Set<string>()
+  const closed = new Set<string>()
+  // g: best known cost from start to v, default is infinity
+  const g = new Map<string, number>()
+  const parent = new Map<string, string>()
+
+  g.set(firstNode.id, 0)
+  open.add(firstNode.id) // insert s with priority h(s)
+
+  let current: Node | null = null
+
+  const graph = await getGraph()
+
+  while (open.size > 0) {
+    const currentId = open.values().next().value as string // node in open with lowest f-value
+    open.delete(currentId)
+    current = graph.nodes.get(currentId) ?? null
+
+    if (current && dest.nodes.some((n) => n.id === current.id)) {
+      return reconstructPath(parent, current.id, graph.nodes)
+    }
+
+    if (current) closed.add(current.id) // add current to closed
+  }
+}

--- a/src/server/graph.functions.ts
+++ b/src/server/graph.functions.ts
@@ -19,7 +19,7 @@ import {
   createTransitNodesInDb,
 } from "./graph.server"
 
-const nodeTypeEnum = z.enum(Object.values(NodeType) as [string, ...string[]])
+export const nodeTypeEnum = z.enum(Object.values(NodeType) as [string, ...string[]])
 
 export const getAllNodesData = createServerFn({ method: "GET" }).handler(async () => {
   return await getAllNodesInDb()

--- a/src/server/graph.server.ts
+++ b/src/server/graph.server.ts
@@ -134,6 +134,13 @@ export class Graph {
   }
 
   // ----------------------------- //
+  // Get all nodes on a given floor
+  // ----------------------------- //
+  getNodesByFloor(floor: number): Node[] {
+    return [...this.nodes.values()].filter((n) => n.floor === floor)
+  }
+
+  // ----------------------------- //
   // Get adjacent edges: A -> [A -> B, A -> C ... ]
   // ----------------------------- //
   getNeighbors(id: Node["id"]): Edge[] {


### PR DESCRIPTION
## Description

This pull request introduces the A star algorithm!!
It closely follows the pseudocode from the report. 

**Generally there are two cases when exploring an edge:**
Case 1: the neighbor hasn't been seen before (not in open, not in closed). Add it to open for the first time with its cost.
Case 2: the neighbor is already in open, but we just found a cheaper way to reach it. Update it with the lower cost and re-sort it in open.

Routing profiles work as intended and the algorithm runs correctly.
The turn angle threshold is as of now set to 30 degrees.

Closes #5 

## How to run
Now you might ask, how did I test it manually. Well while I wrote the implementation of the algorithm without any AI, I did ask my buddy Claude to vibe code some frontend so we can manually test. To access it go to branch:

`git checkout verify/a-star`

## Changes made

- Added A* serverfn
- Added A* function

## Checklist

- [x] PR title follows the format `Feat/`, `Fix/` or `Chore/` (e.g. `Feat/Add A* pathfinding`)
- [x] Self-assigned this PR
- [x] Added relevant labels (e.g. `feature`, `fix`, `chore`)
- [x] Linked a PBI from GitHub Projects
- [x] Manually tested the features touched by the files changed
- [x] Project builds locally (`pnpm build`)
- [x] No unrelated changes snuck in
