### PR TITLE
Feat/navigation UI

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://unpkg.com/knip@6/schema.json",
+  "tags": ["-lintignore"],
+  "ignore": ["src/generated/**", "src/components/ui/**"]
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "lint": "eslint",
     "format": "prettier --check .",
     "check": "prettier --write . && eslint --fix",
-    "ci": "npm run lint && npm run format && npx tsc --noEmit && npm run build"
+    "ci": "npm run lint && npm run format && npx tsc --noEmit && npm run build",
+    "knip": "knip"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
@@ -85,6 +86,7 @@
     "eslint-plugin-unicorn": "^63.0.0",
     "globals": "^17.5.0",
     "jsdom": "^29.0.2",
+    "knip": "^6.9.0",
     "prettier": "^3.8.3",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,13 +31,13 @@ importers:
         version: 0.13.11(typescript@5.9.3)(valibot@1.2.0(typescript@5.9.3))(zod@4.3.6)
       '@tailwindcss/vite':
         specifier: ^4.2.4
-        version: 4.2.4(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+        version: 4.2.4(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/react-devtools':
         specifier: latest
         version: 0.10.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(csstype@3.2.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(solid-js@1.9.12)
       '@tanstack/react-form':
         specifier: latest
-        version: 1.29.1(@tanstack/react-start@1.167.42(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.29.1(@tanstack/react-start@1.167.42(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/react-query':
         specifier: latest
         version: 5.99.2(react@19.2.5)
@@ -55,13 +55,13 @@ importers:
         version: 1.166.11(@tanstack/query-core@5.99.2)(@tanstack/react-query@5.99.2(react@19.2.5))(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/router-core@1.168.15)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/react-start':
         specifier: latest
-        version: 1.167.42(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+        version: 1.167.42(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/router-plugin':
         specifier: ^1.167.22
-        version: 1.167.22(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+        version: 1.167.22(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       better-auth:
         specifier: ^1.6.6
-        version: 1.6.6(@opentelemetry/api@1.9.1)(@prisma/client@7.7.0(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3))(typescript@5.9.3))(@tanstack/react-start@1.167.42(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)))(mysql2@3.15.3)(pg@8.20.0)(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(solid-js@1.9.12)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)))
+        version: 1.6.6(@opentelemetry/api@1.9.1)(@prisma/client@7.7.0(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3))(typescript@5.9.3))(@tanstack/react-start@1.167.42(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(mysql2@3.15.3)(pg@8.20.0)(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(solid-js@1.9.12)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -79,7 +79,7 @@ importers:
         version: 0.577.0(react@19.2.5)
       nitro:
         specifier: npm:nitro-nightly@3.0.1-20260322-095631-ffdd706a
-        version: nitro-nightly@3.0.1-20260322-095631-ffdd706a(@electric-sql/pglite@0.4.1)(chokidar@4.0.3)(dotenv@17.4.2)(giget@2.0.0)(jiti@2.6.1)(lru-cache@11.3.5)(mysql2@3.15.3)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+        version: nitro-nightly@3.0.1-20260322-095631-ffdd706a(@electric-sql/pglite@0.4.1)(chokidar@4.0.3)(dotenv@17.4.2)(giget@2.0.0)(jiti@2.6.1)(lru-cache@11.3.5)(mysql2@3.15.3)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       prisma:
         specifier: ^7.7.0
         version: 7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
@@ -119,7 +119,7 @@ importers:
         version: 0.5.19(tailwindcss@4.2.4)
       '@tanstack/devtools-vite':
         specifier: latest
-        version: 0.6.0(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+        version: 0.6.0(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/eslint-config':
         specifier: latest
         version: 0.4.0(@typescript-eslint/utils@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
@@ -146,7 +146,7 @@ importers:
         version: 0.183.1
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+        version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -189,6 +189,9 @@ importers:
       jsdom:
         specifier: ^29.0.2
         version: 29.0.2(@noble/hashes@2.2.0)
+      knip:
+        specifier: ^6.9.0
+        version: 6.9.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
@@ -203,10 +206,10 @@ importers:
         version: 8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       vite:
         specifier: ^8.0.9
-        version: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)
+        version: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 
@@ -965,8 +968,246 @@ packages:
     resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
     engines: {node: '>=14'}
 
+  '@oxc-parser/binding-android-arm-eabi@0.128.0':
+    resolution: {integrity: sha512-aca6ZvzmCBUGOANQRiRQRZuRKYI3ENhcit6GisnknOOmcezfQc7xJ4dxlPU7MV7mOvrC7RNR1u3LAD7xyaiCxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.128.0':
+    resolution: {integrity: sha512-BbeDmuohoJ7Rz/it5wnkj69i/OsCPS3Z51nLEzwO/Y6YshtC4JU+15oNwhY8v4LRKRYclRc7ggOikwrsJ/eOEQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-darwin-arm64@0.128.0':
+    resolution: {integrity: sha512-tRUHPt80417QmvNpoSslJT1VY8NUbWdrWR+L14Zn+RbOTcaqB8E6PYE/ZGN8jjWBzqporiA/H4MfO50ew/NCNA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.128.0':
+    resolution: {integrity: sha512-rWI2Hb1Nt3U/vKsjyNvZzDC8i/l144U20DKjhzaTmwIhIiSRGeroPWWiImwypmKLqrw8GuIixbWJkpGWLbkzrQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-freebsd-x64@0.128.0':
+    resolution: {integrity: sha512-hhpdVMaNCLgQxjgNPeeFzSeJMmZPc5lKfv0NGSI3egZq9EdnEGqeC8JsYsQjK7PoQgbvZ17xlj0SO5ziH5Obkg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.128.0':
+    resolution: {integrity: sha512-093zNw0zZ/e/obML+rhlSdmnzR0mVZluPcAkxunEc5E3F0yBVsFn24Y1ILfsEte11Ud041qn/gp2OJ1jxNqUng==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.128.0':
+    resolution: {integrity: sha512-fq7DmKmfC+dvD97IXrgbph6Jzwe0EDu+PYMofmzZ6fv5X1k9vtaqLpDGMuICO9MmUnyKAQmVl+wIv2RNy4Dz8g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.128.0':
+    resolution: {integrity: sha512-Xvm48jJah8TlIrURIjNOP/gNiGe6aKvCB+r06VliflFo8Kq7VOLE8PxtgShJzZIqubrgdMdYfvuPPozn7F6MbQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.128.0':
+    resolution: {integrity: sha512-M7iwBGmYJTx+pKOYFjI0buop4gJvlmcVzFGaXPt21DKpQkbQZG1f63Yg7LloIYT/t9yLxCw0Lhfx/RFlAlMSjA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.128.0':
+    resolution: {integrity: sha512-21LGNIZb1Pcfk5/EGsqabrxv4yqQOWis1407JJrClS7XpFCrbvr74YAB1V+m54cYbwvO6UWwQqS4WecxiyfCRg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.128.0':
+    resolution: {integrity: sha512-gyHjOTFpg9bTTYjxPmQirvufb89+VdZwVfcMtAUyPr6F5H8ZswvCQshK4qOW+Q+2Xyb33hduRgY/eFHJQjU/vQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.128.0':
+    resolution: {integrity: sha512-X6Q2oKUrP5GyDd2xniuEBLk6aFQCZ97W2+aVXGgJXdjx5t4/oFuA9ri0wLOUrBIX+qdSuK581snMBio4z910eA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.128.0':
+    resolution: {integrity: sha512-BdzTmqxfxoYkpgokoLaSnOX6T+R3/goL42klre2tnG+kHbG2TXS0VN+P5BPofH1axdKOHy5ei4ENZrjmCOt2lA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.128.0':
+    resolution: {integrity: sha512-OO1nW2Q7sSYYvJZpDHdvyFSdRaVcQqRijZSSmWVMqFxPYy8cEF45zJ9fcdIYuzIT3jYq6YRhEFm/VMWNWhE22Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-musl@0.128.0':
+    resolution: {integrity: sha512-4NehAe404MRdoZVS9DW8C5XbJwbXIc/KfVlYdpi5vE4081zc9Y0YzKVqyOYj/Puye7/Do+ohaONBFWlEHYl9hw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-openharmony-arm64@0.128.0':
+    resolution: {integrity: sha512-kVbqgW9xLL8bh8oc7aYOJilRKXE5G33+tE0jan+duo/9OriaFRpijcCwT2waWs2oqYROYq0GlE7/p3ywoshVeg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-wasm32-wasi@0.128.0':
+    resolution: {integrity: sha512-L38ojghJYHmgiz6fJd7jwLB/ESDBpB02NdFxh+smqVM6P2anCEvHn0jhaSrt5eVNR1Ak8+moOeftUlofeyvniA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.128.0':
+    resolution: {integrity: sha512-xgvO35GyHBtjlQ5AEpaYr7Rll1rvY7zqIhT6ty8E3ezBW2J1SFLjIDEvI/tcgDg6oaseDAqVcM+jU1HuCekgZw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.128.0':
+    resolution: {integrity: sha512-OY+3eM2SN72prHKRB22mPz8o5A/7dJ+f5DFLBVvggyZhEaNDAH9IB+ElMjmOkOIwf5MDCUAowCK7pAncNxzpBA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.128.0':
+    resolution: {integrity: sha512-NE9ny+cPUCCObXa0IKLfj0tCdPd7pe/dz9ZpkxpUOymB3miNeMPybdlYYTBSGJUalMWeBM85/4JcCErCNTqOXw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@oxc-project/types@0.126.0':
     resolution: {integrity: sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==}
+
+  '@oxc-project/types@0.128.0':
+    resolution: {integrity: sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==}
+
+  '@oxc-resolver/binding-android-arm-eabi@11.19.1':
+    resolution: {integrity: sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg==}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-resolver/binding-android-arm64@11.19.1':
+    resolution: {integrity: sha512-oolbkRX+m7Pq2LNjr/kKgYeC7bRDMVTWPgxBGMjSpZi/+UskVo4jsMU3MLheZV55jL6c3rNelPl4oD60ggYmqA==}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-resolver/binding-darwin-arm64@11.19.1':
+    resolution: {integrity: sha512-nUC6d2i3R5B12sUW4O646qD5cnMXf2oBGPLIIeaRfU9doJRORAbE2SGv4eW6rMqhD+G7nf2Y8TTJTLiiO3Q/dQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-darwin-x64@11.19.1':
+    resolution: {integrity: sha512-cV50vE5+uAgNcFa3QY1JOeKDSkM/9ReIcc/9wn4TavhW/itkDGrXhw9jaKnkQnGbjJ198Yh5nbX/Gr2mr4Z5jQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-freebsd-x64@11.19.1':
+    resolution: {integrity: sha512-xZOQiYGFxtk48PBKff+Zwoym7ScPAIVp4c14lfLxizO2LTTTJe5sx9vQNGrBymrf/vatSPNMD4FgsaaRigPkqw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.19.1':
+    resolution: {integrity: sha512-lXZYWAC6kaGe/ky2su94e9jN9t6M0/6c+GrSlCqL//XO1cxi5lpAhnJYdyrKfm0ZEr/c7RNyAx3P7FSBcBd5+A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.19.1':
+    resolution: {integrity: sha512-veG1kKsuK5+t2IsO9q0DErYVSw2azvCVvWHnfTOS73WE0STdLLB7Q1bB9WR+yHPQM76ASkFyRbogWo1GR1+WbQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm64-gnu@11.19.1':
+    resolution: {integrity: sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-arm64-musl@11.19.1':
+    resolution: {integrity: sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.19.1':
+    resolution: {integrity: sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.19.1':
+    resolution: {integrity: sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.19.1':
+    resolution: {integrity: sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.19.1':
+    resolution: {integrity: sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-x64-gnu@11.19.1':
+    resolution: {integrity: sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-x64-musl@11.19.1':
+    resolution: {integrity: sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-openharmony-arm64@11.19.1':
+    resolution: {integrity: sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-resolver/binding-wasm32-wasi@11.19.1':
+    resolution: {integrity: sha512-w8UCKhX826cP/ZLokXDS6+milN8y4X7zidsAttEdWlVoamTNf6lhBJldaWr3ukTDiye7s4HRcuPEPOXNC432Vg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-resolver/binding-win32-arm64-msvc@11.19.1':
+    resolution: {integrity: sha512-nJ4AsUVZrVKwnU/QRdzPCCrO0TrabBqgJ8pJhXITdZGYOV28TIYystV1VFLbQ7DtAcaBHpocT5/ZJnF78YJPtQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-resolver/binding-win32-ia32-msvc@11.19.1':
+    resolution: {integrity: sha512-EW+ND5q2Tl+a3pH81l1QbfgbF3HmqgwLfDfVithRFheac8OTcnbXt/JxqD2GbDkb7xYEqy1zNaVFRr3oeG8npA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-resolver/binding-win32-x64-msvc@11.19.1':
+    resolution: {integrity: sha512-6hIU3RQu45B+VNTY4Ru8ppFwjVS/S5qwYyGhBotmjxfEKk41I2DlGtRfGJndZ5+6lneE2pwloqunlOyZuX/XAw==}
+    cpu: [x64]
+    os: [win32]
 
   '@package-json/types@0.0.12':
     resolution: {integrity: sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==}
@@ -1179,36 +1420,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.16':
     resolution: {integrity: sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.16':
     resolution: {integrity: sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.16':
     resolution: {integrity: sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.16':
     resolution: {integrity: sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.16':
     resolution: {integrity: sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.16':
     resolution: {integrity: sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==}
@@ -1346,24 +1593,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
     resolution: {integrity: sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
     resolution: {integrity: sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.4':
     resolution: {integrity: sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.4':
     resolution: {integrity: sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==}
@@ -1838,41 +2089,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -3006,6 +3265,9 @@ packages:
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
+  fd-package-json@2.0.0:
+    resolution: {integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -3067,6 +3329,11 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
+
+  formatly@0.3.0:
+    resolution: {integrity: sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==}
+    engines: {node: '>=18.3.0'}
+    hasBin: true
 
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
@@ -3635,6 +3902,11 @@ packages:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
+  knip@6.9.0:
+    resolution: {integrity: sha512-2GLjxteBwmsSA3Z5sJZpPDaNPBIMnlm4/9Nx4CZadEK7YccJZ2/4kwKgPWhVYEqxhwhD0WO4txWXNGTO/Odkkg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   kysely@0.28.16:
     resolution: {integrity: sha512-3i5pmOiZvMDj00qhrIVbH0AnioVTx22DMP7Vn5At4yJO46iy+FM8Y/g61ltenLVSo3fiO8h8Q3QOFgf/gQ72ww==}
     engines: {node: '>=20.0.0'}
@@ -3691,24 +3963,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -4033,6 +4309,13 @@ packages:
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
+
+  oxc-parser@0.128.0:
+    resolution: {integrity: sha512-XkOw3eiIxAgQ19WRew/Bq9wc5Ga/guaWIzDBzq80z1PyuDNGvWBpPby9k6YGwV8A8uMw+Nlq3xqlzuDYmUFYUw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  oxc-resolver@11.19.1:
+    resolution: {integrity: sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg==}
 
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
@@ -4523,6 +4806,10 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  smol-toml@1.6.1:
+    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
+    engines: {node: '>= 18'}
+
   solid-js@1.9.12:
     resolution: {integrity: sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw==}
 
@@ -4650,6 +4937,10 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-json-comments@5.0.3:
+    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
+    engines: {node: '>=14.16'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -4825,6 +5116,10 @@ packages:
 
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  unbash@3.0.0:
+    resolution: {integrity: sha512-FeFPZ/WFT0mbRCuydiZzpPFlrYN8ZUpphQKoq4EeElVIYjYyGzPMxQR/simUwCOJIyVhpFk4RbtyO7RuMpMnHA==}
+    engines: {node: '>=14'}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -5075,6 +5370,10 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
+  walk-up-path@4.0.0:
+    resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
+    engines: {node: 20 || >=22}
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
@@ -5188,6 +5487,11 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
@@ -5909,6 +6213,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:
       '@emnapi/core': 1.9.2
@@ -5973,7 +6284,138 @@ snapshots:
 
   '@opentelemetry/semantic-conventions@1.40.0': {}
 
+  '@oxc-parser/binding-android-arm-eabi@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.128.0':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.128.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.128.0':
+    optional: true
+
   '@oxc-project/types@0.126.0': {}
+
+  '@oxc-project/types@0.128.0': {}
+
+  '@oxc-resolver/binding-android-arm-eabi@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-android-arm64@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-arm64@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-x64@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-freebsd-x64@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-gnu@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-musl@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-gnu@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-musl@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-openharmony-arm64@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
+  '@oxc-resolver/binding-win32-arm64-msvc@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-win32-ia32-msvc@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-win32-x64-msvc@11.19.1':
+    optional: true
 
   '@package-json/types@0.0.12': {}
 
@@ -6364,12 +6806,12 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.2.4
 
-  '@tailwindcss/vite@4.2.4(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))':
+  '@tailwindcss/vite@4.2.4(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@tailwindcss/node': 4.2.4
       '@tailwindcss/oxide': 4.2.4
       tailwindcss: 4.2.4
-      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@tanstack/devtools-client@0.0.6':
     dependencies:
@@ -6393,7 +6835,7 @@ snapshots:
     transitivePeerDependencies:
       - csstype
 
-  '@tanstack/devtools-vite@0.6.0(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))':
+  '@tanstack/devtools-vite@0.6.0(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -6405,7 +6847,7 @@ snapshots:
       chalk: 5.6.2
       launch-editor: 2.13.2
       picomatch: 4.0.4
-      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -6470,13 +6912,13 @@ snapshots:
       - solid-js
       - utf-8-validate
 
-  '@tanstack/react-form@1.29.1(@tanstack/react-start@1.167.42(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@tanstack/react-form@1.29.1(@tanstack/react-start@1.167.42(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@tanstack/form-core': 1.29.1
       '@tanstack/react-store': 0.9.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
     optionalDependencies:
-      '@tanstack/react-start': 1.167.42(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+      '@tanstack/react-start': 1.167.42(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - react-dom
 
@@ -6530,7 +6972,7 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@tanstack/react-start-rsc@0.0.21(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))':
+  '@tanstack/react-start-rsc@0.0.21(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@tanstack/react-router': 1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/react-start-server': 1.166.41(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -6538,7 +6980,7 @@ snapshots:
       '@tanstack/router-utils': 1.161.6
       '@tanstack/start-client-core': 1.167.17
       '@tanstack/start-fn-stubs': 1.161.6
-      '@tanstack/start-plugin-core': 1.167.35(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.15))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+      '@tanstack/start-plugin-core': 1.167.35(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.15))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/start-server-core': 1.167.19(crossws@0.4.5(srvx@0.11.15))
       '@tanstack/start-storage-context': 1.166.29
       pathe: 2.0.3
@@ -6564,20 +7006,20 @@ snapshots:
     transitivePeerDependencies:
       - crossws
 
-  '@tanstack/react-start@1.167.42(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))':
+  '@tanstack/react-start@1.167.42(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@tanstack/react-router': 1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/react-start-client': 1.166.40(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@tanstack/react-start-rsc': 0.0.21(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+      '@tanstack/react-start-rsc': 0.0.21(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/react-start-server': 1.166.41(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/router-utils': 1.161.6
       '@tanstack/start-client-core': 1.167.17
-      '@tanstack/start-plugin-core': 1.167.35(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.15))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+      '@tanstack/start-plugin-core': 1.167.35(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.15))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/start-server-core': 1.167.19(crossws@0.4.5(srvx@0.11.15))
       pathe: 2.0.3
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@rsbuild/core'
       - crossws
@@ -6620,7 +7062,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.167.22(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))':
+  '@tanstack/router-plugin@1.167.22(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
@@ -6637,7 +7079,7 @@ snapshots:
       zod: 3.25.76
     optionalDependencies:
       '@tanstack/react-router': 1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -6669,7 +7111,7 @@ snapshots:
 
   '@tanstack/start-fn-stubs@1.161.6': {}
 
-  '@tanstack/start-plugin-core@1.167.35(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.15))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))':
+  '@tanstack/start-plugin-core@1.167.35(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.15))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.29.0
@@ -6677,7 +7119,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.40
       '@tanstack/router-core': 1.168.15
       '@tanstack/router-generator': 1.166.32
-      '@tanstack/router-plugin': 1.167.22(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+      '@tanstack/router-plugin': 1.167.22(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/router-utils': 1.161.6
       '@tanstack/start-client-core': 1.167.17
       '@tanstack/start-server-core': 1.167.19(crossws@0.4.5(srvx@0.11.15))
@@ -6690,8 +7132,8 @@ snapshots:
       srvx: 0.11.15
       tinyglobby: 0.2.16
       ufo: 1.6.3
-      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)
-      vitefu: 1.1.3(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitefu: 1.1.3(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       xmlbuilder2: 4.0.3
       zod: 3.25.76
     transitivePeerDependencies:
@@ -6984,10 +7426,10 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 19.2.5
 
-  '@vitejs/plugin-react@6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))':
+  '@vitejs/plugin-react@6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     optionalDependencies:
       babel-plugin-react-compiler: 1.0.0
 
@@ -7000,14 +7442,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.5(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.13.4(@types/node@25.6.0)(typescript@5.9.3)
-      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -7201,7 +7643,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.20: {}
 
-  better-auth@1.6.6(@opentelemetry/api@1.9.1)(@prisma/client@7.7.0(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3))(typescript@5.9.3))(@tanstack/react-start@1.167.42(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)))(mysql2@3.15.3)(pg@8.20.0)(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(solid-js@1.9.12)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))):
+  better-auth@1.6.6(@opentelemetry/api@1.9.1)(@prisma/client@7.7.0(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3))(typescript@5.9.3))(@tanstack/react-start@1.167.42(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(mysql2@3.15.3)(pg@8.20.0)(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(solid-js@1.9.12)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))):
     dependencies:
       '@better-auth/core': 1.6.6(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.6(@better-auth/core@1.6.6(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
@@ -7222,14 +7664,14 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       '@prisma/client': 7.7.0(prisma@7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3))(typescript@5.9.3)
-      '@tanstack/react-start': 1.167.42(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+      '@tanstack/react-start': 1.167.42(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       mysql2: 3.15.3
       pg: 8.20.0
       prisma: 7.7.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       solid-js: 1.9.12
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -8266,6 +8708,10 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  fd-package-json@2.0.0:
+    dependencies:
+      walk-up-path: 4.0.0
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -8328,6 +8774,10 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  formatly@0.3.0:
+    dependencies:
+      fd-package-json: 2.0.0
 
   formdata-polyfill@4.0.10:
     dependencies:
@@ -8848,6 +9298,26 @@ snapshots:
 
   kleur@4.1.5: {}
 
+  knip@6.9.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      formatly: 0.3.0
+      get-tsconfig: 4.14.0
+      jiti: 2.6.1
+      minimist: 1.2.8
+      oxc-parser: 0.128.0
+      oxc-resolver: 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      picomatch: 4.0.4
+      smol-toml: 1.6.1
+      strip-json-comments: 5.0.3
+      tinyglobby: 0.2.16
+      unbash: 3.0.0
+      yaml: 2.8.3
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
   kysely@0.28.16: {}
 
   language-subtag-registry@0.3.23: {}
@@ -9061,7 +9531,7 @@ snapshots:
 
   nf3@0.3.16: {}
 
-  nitro-nightly@3.0.1-20260322-095631-ffdd706a(@electric-sql/pglite@0.4.1)(chokidar@4.0.3)(dotenv@17.4.2)(giget@2.0.0)(jiti@2.6.1)(lru-cache@11.3.5)(mysql2@3.15.3)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)):
+  nitro-nightly@3.0.1-20260322-095631-ffdd706a(@electric-sql/pglite@0.4.1)(chokidar@4.0.3)(dotenv@17.4.2)(giget@2.0.0)(jiti@2.6.1)(lru-cache@11.3.5)(mysql2@3.15.3)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.5(srvx@0.11.15)
@@ -9081,7 +9551,7 @@ snapshots:
       dotenv: 17.4.2
       giget: 2.0.0
       jiti: 2.6.1
-      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -9260,6 +9730,57 @@ snapshots:
       get-intrinsic: 1.3.0
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
+
+  oxc-parser@0.128.0:
+    dependencies:
+      '@oxc-project/types': 0.128.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.128.0
+      '@oxc-parser/binding-android-arm64': 0.128.0
+      '@oxc-parser/binding-darwin-arm64': 0.128.0
+      '@oxc-parser/binding-darwin-x64': 0.128.0
+      '@oxc-parser/binding-freebsd-x64': 0.128.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.128.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.128.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.128.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.128.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.128.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.128.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.128.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.128.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.128.0
+      '@oxc-parser/binding-linux-x64-musl': 0.128.0
+      '@oxc-parser/binding-openharmony-arm64': 0.128.0
+      '@oxc-parser/binding-wasm32-wasi': 0.128.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.128.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.128.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.128.0
+
+  oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+    optionalDependencies:
+      '@oxc-resolver/binding-android-arm-eabi': 11.19.1
+      '@oxc-resolver/binding-android-arm64': 11.19.1
+      '@oxc-resolver/binding-darwin-arm64': 11.19.1
+      '@oxc-resolver/binding-darwin-x64': 11.19.1
+      '@oxc-resolver/binding-freebsd-x64': 11.19.1
+      '@oxc-resolver/binding-linux-arm-gnueabihf': 11.19.1
+      '@oxc-resolver/binding-linux-arm-musleabihf': 11.19.1
+      '@oxc-resolver/binding-linux-arm64-gnu': 11.19.1
+      '@oxc-resolver/binding-linux-arm64-musl': 11.19.1
+      '@oxc-resolver/binding-linux-ppc64-gnu': 11.19.1
+      '@oxc-resolver/binding-linux-riscv64-gnu': 11.19.1
+      '@oxc-resolver/binding-linux-riscv64-musl': 11.19.1
+      '@oxc-resolver/binding-linux-s390x-gnu': 11.19.1
+      '@oxc-resolver/binding-linux-x64-gnu': 11.19.1
+      '@oxc-resolver/binding-linux-x64-musl': 11.19.1
+      '@oxc-resolver/binding-openharmony-arm64': 11.19.1
+      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@oxc-resolver/binding-win32-arm64-msvc': 11.19.1
+      '@oxc-resolver/binding-win32-ia32-msvc': 11.19.1
+      '@oxc-resolver/binding-win32-x64-msvc': 11.19.1
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
   p-limit@3.1.0:
     dependencies:
@@ -9817,6 +10338,8 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  smol-toml@1.6.1: {}
+
   solid-js@1.9.12:
     dependencies:
       csstype: 3.2.3
@@ -9946,6 +10469,8 @@ snapshots:
   strip-indent@4.1.1: {}
 
   strip-json-comments@3.1.1: {}
+
+  strip-json-comments@5.0.3: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -10138,6 +10663,8 @@ snapshots:
 
   ufo@1.6.3: {}
 
+  unbash@3.0.0: {}
+
   unbox-primitive@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -10225,7 +10752,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0):
+  vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -10238,15 +10765,16 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       tsx: 4.21.0
+      yaml: 2.8.3
 
-  vitefu@1.1.3(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)):
+  vitefu@1.1.3(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     optionalDependencies:
-      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
-  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)):
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+      '@vitest/mocker': 4.1.5(msw@2.13.4(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -10263,7 +10791,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -10287,6 +10815,8 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
+
+  walk-up-path@4.0.0: {}
 
   web-streams-polyfill@3.3.3: {}
 
@@ -10401,6 +10931,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yaml@2.8.3: {}
 
   yargs-parser@21.1.1: {}
 

--- a/src/components/forms/use-floor-form.ts
+++ b/src/components/forms/use-floor-form.ts
@@ -10,11 +10,11 @@ export const ACCEPTED_IMAGE_TYPES = {
   "image/png": [".png"],
   "image/jpeg": [".jpg", ".jpeg"],
 }
-export const MAX_FILE_SIZE = 10 * 1024 * 1024
+const MAX_FILE_SIZE = 10 * 1024 * 1024
 
 type UploadState = "idle" | "uploading" | "success" | "error"
 
-export const formSchema = z.object({
+const formSchema = z.object({
   file: z
     .instanceof(File, { message: "Please upload an image" })
     .refine((f) => f.size <= MAX_FILE_SIZE, "Image must be 10 MB or smaller")

--- a/src/components/map/action-bar/action-bar.tsx
+++ b/src/components/map/action-bar/action-bar.tsx
@@ -89,6 +89,7 @@ const ActionBarShell = ({
   </div>
 )
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
 const ModeLabel = ({ icon: Icon, label }: { icon: LucideIcon; label: string }) => (
   <span className="flex items-center gap-2 whitespace-nowrap text-xs font-semibold md:pr-1">
     <Icon className="size-4" />

--- a/src/components/map/action-bar/action-bar.tsx
+++ b/src/components/map/action-bar/action-bar.tsx
@@ -1,6 +1,8 @@
-import { LogOut } from "lucide-react"
+import { Check, Crosshair, LogOut, X } from "lucide-react"
 
+import { mapFromWorld } from "#/lib/coordinates"
 import { useMap } from "#/lib/map-context"
+import { useNavigation } from "#/lib/navigation-context"
 import { getToolMeta } from "#/lib/tool-registry"
 import { cn } from "@/lib/utils"
 
@@ -8,24 +10,165 @@ import { DrawNodeActions } from "./draw-node-actions"
 import { DrawRoomActions } from "./draw-room-actions"
 import { PillButton, PillDivider } from "./pill-button"
 
+import type { LucideIcon } from "lucide-react"
+import type { ReactNode } from "react"
+
 interface ActionBarProps {
+  /** Extra classes for the outer wrapper (positioning is owned by the shell). */
   className?: string
 }
 
+interface ToastProps {
+  variant?: "error" | "info"
+  children: ReactNode
+}
+
+const Toast = ({ variant = "info", children }: ToastProps) => (
+  <div
+    role={variant === "error" ? "alert" : "status"}
+    className={cn(
+      "pointer-events-none rounded-full border px-4 py-1.5 text-xs font-semibold shadow-xl backdrop-blur-sm",
+      variant === "error"
+        ? "border-red-500/50 bg-red-600/95 text-white"
+        : "border-border/60 bg-popover text-popover-foreground",
+    )}
+  >
+    {children}
+  </div>
+)
+
+interface ActionBarShellProps {
+  ariaLabel: string
+  /**
+   * Leading content inside the bar. Pass a small icon+label for tool modes,
+   * or breakpoint-responsive content for modes that want different copy at
+   * different sizes (e.g. an inline hint on mobile).
+   */
+  modeContent: ReactNode
+  /** Optional toast that floats above the bar (tool validation errors). */
+  toast?: ReactNode
+  toastVariant?: "error" | "info"
+  className?: string
+  children: ReactNode
+}
+
 /**
- * Contextual action bar shown at the bottom-center while a tool is active.
+ * The shared chrome behind every ActionBar variant. Renders full-width along
+ * the bottom edge on mobile (matches the navigation pick-start design), and
+ * collapses to a centered pill at `md+`.
+ */
+const ActionBarShell = ({
+  ariaLabel,
+  modeContent,
+  toast,
+  toastVariant = "info",
+  className,
+  children,
+}: ActionBarShellProps) => (
+  <div
+    className={cn(
+      "pointer-events-auto fixed inset-x-0 bottom-0 z-30 flex flex-col items-center gap-2",
+      "md:absolute md:inset-x-auto md:bottom-6 md:left-1/2 md:-translate-x-1/2",
+      className,
+    )}
+  >
+    {toast && <Toast variant={toastVariant}>{toast}</Toast>}
+    <div
+      role="toolbar"
+      aria-label={ariaLabel}
+      className={cn(
+        // Mobile: full-width bottom bar, popover-styled, stacked content.
+        "flex w-full flex-col gap-3 border-t border-border bg-popover p-4 text-popover-foreground shadow-2xl",
+        // Desktop: collapse to a centered primary-colored pill.
+        "md:w-auto md:flex-row md:items-center md:gap-1 md:rounded-full md:border md:border-slate-700/50 md:bg-primary md:p-0 md:px-3 md:py-2 md:text-white md:shadow-xl md:backdrop-blur-sm",
+      )}
+    >
+      {modeContent}
+      <div className="flex flex-row items-center justify-end gap-2 md:contents">{children}</div>
+    </div>
+  </div>
+)
+
+const ModeLabel = ({ icon: Icon, label }: { icon: LucideIcon; label: string }) => (
+  <span className="flex items-center gap-2 whitespace-nowrap text-xs font-semibold md:pr-1">
+    <Icon className="size-4" />
+    {label}
+  </span>
+)
+
+/**
+ * Contextual action bar shown at the bottom while a tool is active or while
+ * the navigation flow is in pick-start mode.
  *
- * Renders as a single wide pill so all actions for the current tool feel
- * like one UI element:
- * - Left: mode icon + label (from the tool registry).
- * - Middle: tool-specific actions (e.g. undo / discard / snap-to-grid for
- *   draw-room).
- * - Right: an "Exit mode" button that clears `activeTool`.
+ * - Admin tool mode: mode icon + label, tool-specific actions (e.g. undo /
+ *   discard / snap-to-grid), and an "Exit mode" button.
+ * - Pick-start mode: a hint toast above, mode icon + label, and Cancel /
+ *   Confirm location actions. Reads `OrbitControls.target` on confirm and
+ *   writes a `MapPickedPoint` to the navigation context.
  *
- * Validation errors float above the pill as a matching toast.
+ * Validation errors (draw-room only) float above the bar as a red toast.
  */
 export const ActionBar = ({ className }: ActionBarProps) => {
-  const { activeTool, drawing, setActiveTool } = useMap()
+  const {
+    activeTool,
+    drawing,
+    setActiveTool,
+    pickingStart,
+    setPickingStart,
+    controlsRef,
+    currentFloor,
+  } = useMap()
+  const { setStart } = useNavigation()
+
+  if (pickingStart) {
+    const handleConfirm = () => {
+      const target = controlsRef.current?.target
+      if (!target || currentFloor === null) return
+      // OrbitControls.target is in three.js space; the navigation context
+      // stores picks in map coordinates so they share a shape with Node.
+      const map = mapFromWorld(target)
+      setStart({ x: map.x, y: map.y, floor: currentFloor })
+      setPickingStart(false)
+    }
+
+    const handleCancel = () => {
+      setPickingStart(false)
+    }
+
+    return (
+      <ActionBarShell
+        ariaLabel="Pick start location"
+        className={className}
+        modeContent={
+          <>
+            {/* Mobile: actionable hint sits inside the bar (no toast floating
+                above the floating controls). Desktop: compact mode label. */}
+            <p className="text-sm md:hidden">
+              Drag the map to position the bullseye, then confirm.
+            </p>
+            <span className="hidden md:inline-flex md:items-center md:gap-2 md:pr-1 md:text-xs md:font-semibold md:whitespace-nowrap">
+              <Crosshair className="size-4" />
+              Picking start location
+            </span>
+          </>
+        }
+      >
+        <PillButton
+          icon={<X className="size-4" />}
+          label="Cancel"
+          onClick={handleCancel}
+          prominentLabel
+        />
+        <PillDivider />
+        <PillButton
+          icon={<Check className="size-4" />}
+          label="Confirm location"
+          onClick={handleConfirm}
+          prominentLabel
+        />
+      </ActionBarShell>
+    )
+  }
 
   if (activeTool === "default") return null
 
@@ -39,42 +182,27 @@ export const ActionBar = ({ className }: ActionBarProps) => {
     ) : null
 
   return (
-    <div className={cn("flex flex-col items-center gap-2", className)}>
-      {validationError && (
-        <div
-          role="alert"
-          className="rounded-full border border-red-500/50 bg-red-600/95 px-4 py-1.5 text-xs font-semibold text-white shadow-xl backdrop-blur-sm"
-        >
-          {validationError}
-        </div>
+    <ActionBarShell
+      ariaLabel="Tool actions"
+      modeContent={<ModeLabel icon={Icon} label={activeLabel} />}
+      toast={validationError ?? undefined}
+      toastVariant="error"
+      className={className}
+    >
+      {toolActions && (
+        <>
+          {toolActions}
+          <PillDivider />
+        </>
       )}
-      <div
-        role="toolbar"
-        aria-label="Tool actions"
-        className={cn(
-          "flex items-center gap-1 px-3 py-2",
-          "rounded-full bg-primary border border-slate-700/50 shadow-xl backdrop-blur-sm",
-        )}
-      >
-        <span className="flex items-center gap-2 pr-1 text-xs font-semibold text-white">
-          <Icon className="size-4" />
-          {activeLabel}
-        </span>
-        {toolActions && (
-          <>
-            <PillDivider />
-            {toolActions}
-          </>
-        )}
-        <PillDivider />
-        <PillButton
-          icon={<LogOut className="size-4" />}
-          label="Exit mode"
-          onClick={() => {
-            setActiveTool("default")
-          }}
-        />
-      </div>
-    </div>
+      <PillButton
+        icon={<LogOut className="size-4" />}
+        label="Exit mode"
+        onClick={() => {
+          setActiveTool("default")
+        }}
+        prominentLabel
+      />
+    </ActionBarShell>
   )
 }

--- a/src/components/map/action-bar/pill-button.tsx
+++ b/src/components/map/action-bar/pill-button.tsx
@@ -23,13 +23,7 @@ interface PillButtonProps {
  * button variant so hover / pressed styling stays consistent with any other
  * toolbar-style buttons the app adds later.
  */
-export const PillButton = ({
-  icon,
-  label,
-  disabled,
-  onClick,
-  prominentLabel,
-}: PillButtonProps) => (
+export const PillButton = ({ icon, label, disabled, onClick, prominentLabel }: PillButtonProps) => (
   <Tooltip>
     <TooltipTrigger
       render={

--- a/src/components/map/action-bar/pill-button.tsx
+++ b/src/components/map/action-bar/pill-button.tsx
@@ -1,5 +1,6 @@
 import { Button } from "#/components/ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "#/components/ui/tooltip"
+import { cn } from "@/lib/utils"
 
 import type { ReactNode } from "react"
 
@@ -8,6 +9,13 @@ interface PillButtonProps {
   label: string
   disabled?: boolean
   onClick: () => void
+  /**
+   * When true, renders the label inline next to the icon on mobile so
+   * touch users get a readable button. Reverts to the icon-round shape on
+   * `md+` (with the tooltip still attached). Use for primary actions like
+   * Cancel / Confirm / Exit, where tooltip-only is poor on touch.
+   */
+  prominentLabel?: boolean
 }
 
 /**
@@ -15,7 +23,13 @@ interface PillButtonProps {
  * button variant so hover / pressed styling stays consistent with any other
  * toolbar-style buttons the app adds later.
  */
-export const PillButton = ({ icon, label, disabled, onClick }: PillButtonProps) => (
+export const PillButton = ({
+  icon,
+  label,
+  disabled,
+  onClick,
+  prominentLabel,
+}: PillButtonProps) => (
   <Tooltip>
     <TooltipTrigger
       render={
@@ -26,8 +40,13 @@ export const PillButton = ({ icon, label, disabled, onClick }: PillButtonProps) 
           onClick={onClick}
           disabled={disabled}
           aria-label={label}
+          className={cn(
+            prominentLabel &&
+              "h-10 w-auto gap-2 rounded-full px-4 text-sm font-semibold md:size-9 md:gap-0 md:px-0",
+          )}
         >
           {icon}
+          {prominentLabel && <span className="md:hidden">{label}</span>}
         </Button>
       }
     />
@@ -35,4 +54,6 @@ export const PillButton = ({ icon, label, disabled, onClick }: PillButtonProps) 
   </Tooltip>
 )
 
-export const PillDivider = () => <div className="h-6 w-px bg-slate-600/60" aria-hidden />
+export const PillDivider = () => (
+  <div className="hidden h-6 w-px bg-slate-600/60 md:block" aria-hidden />
+)

--- a/src/components/map/search/fuzzy-search-bar.tsx
+++ b/src/components/map/search/fuzzy-search-bar.tsx
@@ -3,11 +3,9 @@ import { useState } from "react"
 import { useFuzzySearch } from "#/components/hooks/use-fuse"
 import { SearchBar } from "#/components/ui/search-bar"
 import { useMap } from "#/lib/map-context"
-import { getRoomTypeMeta, getRoomTypeOutline } from "#/lib/room-types"
+import { roomToSearchResultItem, type RoomSearchResultItem } from "#/lib/room-format"
 
 import type { SearchResultItem } from "#/components/ui/search-result-list"
-
-type SearchResultItemWithDbId = SearchResultItem & { dbId: string }
 
 export const FuzzySearchBar = ({ className }: { className?: string }) => {
   const { setViewingRoomId, setEditingRoomId, activeTool } = useMap()
@@ -15,21 +13,9 @@ export const FuzzySearchBar = ({ className }: { className?: string }) => {
   const { results, isLoading } = useFuzzySearch(query)
   const hasQuery = query.trim().length > 0
 
-  const fuzzyResults: SearchResultItem[] = isLoading
+  const fuzzyResults: RoomSearchResultItem[] = isLoading
     ? []
-    : results.map((r) => {
-        const meta = getRoomTypeMeta(r.item.type)
-        const outline = getRoomTypeOutline(r.item.type)
-        const Icon = meta.icon
-        return {
-          id: r.item.roomNumber,
-          icon: <Icon className="w-5 h-5" style={{ color: outline }} />,
-          iconBgStyle: { backgroundColor: meta.color, outline: `2px solid ${outline}` },
-          title: r.item.displayName ?? "",
-          type: meta.label,
-          dbId: r.item.id,
-        }
-      })
+    : results.map((r) => roomToSearchResultItem(r.item))
   const noResults = hasQuery && !isLoading && fuzzyResults.length === 0
 
   const displayResults: SearchResultItem[] = noResults
@@ -57,7 +43,7 @@ export const FuzzySearchBar = ({ className }: { className?: string }) => {
       results={displayResults}
       onResultClick={(item) => {
         if (item.id === "no results found") return
-        const { dbId } = item as SearchResultItemWithDbId
+        const { dbId } = item as RoomSearchResultItem
         if (activeTool === "default") {
           setViewingRoomId(dbId)
         } else if (["draw-room", "edit-room", "draw-node", "connect-edge"].includes(activeTool)) {

--- a/src/components/panels/navigation/map-pick-overlay.tsx
+++ b/src/components/panels/navigation/map-pick-overlay.tsx
@@ -1,84 +1,22 @@
-import { Check, X } from "lucide-react"
-
-import { Button } from "#/components/ui/button"
-import { mapFromWorld } from "#/lib/coordinates"
 import { useMap } from "#/lib/map-context"
-import { useNavigation } from "#/lib/navigation-context"
 
 /**
- * Overlay shown while the user is picking a start coordinate on the map.
- *
- * Two pieces:
- * - Centered bullseye crosshair that the user pans the map under.
- * - Bottom action bar containing the hint copy + Cancel / Confirm.
- *   On mobile this fills the bottom edge (replacing the navigation panel,
- *   which is hidden while picking). On desktop it's a centered pill.
- *
- * Confirm reads `OrbitControls.target` — the world point under viewport
- * center — and writes it to the navigation context as `{ x, y, z, floor }`.
- * Accurate in 2D top-down (the default). In 3D the target may not lie on
- * the floor plane but it's still the camera's focal point — coarse but
- * reasonable.
+ * Bullseye crosshair shown at viewport center while the user is picking a
+ * start coordinate on the map. The accompanying Cancel / Confirm action bar
+ * is owned by `<ActionBar />` (admin tools and pick-start share that shell).
  */
 export const MapPickOverlay = () => {
-  const { pickingStart, setPickingStart, controlsRef, currentFloor } = useMap()
-  const { setStart } = useNavigation()
+  const { pickingStart } = useMap()
 
   if (!pickingStart) return null
 
-  const handleConfirm = () => {
-    const target = controlsRef.current?.target
-    if (!target || currentFloor === null) return
-    // OrbitControls.target is in three.js space; the navigation context
-    // stores picks in map coordinates so they share a shape with Node.
-    const map = mapFromWorld(target)
-    setStart({ x: map.x, y: map.y, floor: currentFloor })
-    setPickingStart(false)
-  }
-
-  const handleCancel = () => {
-    setPickingStart(false)
-  }
-
   return (
-    <>
-      {/* Bullseye at viewport center */}
-      <div className="pointer-events-none absolute top-1/2 left-1/2 z-20 -translate-x-1/2 -translate-y-1/2">
-        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/20 ring-2 ring-primary">
-          <div className="flex h-6 w-6 items-center justify-center rounded-full bg-primary/40 ring-2 ring-primary">
-            <div className="h-2 w-2 rounded-full bg-primary" />
-          </div>
+    <div className="pointer-events-none absolute top-1/2 left-1/2 z-20 -translate-x-1/2 -translate-y-1/2">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/20 ring-2 ring-primary">
+        <div className="flex h-6 w-6 items-center justify-center rounded-full bg-primary/40 ring-2 ring-primary">
+          <div className="h-2 w-2 rounded-full bg-primary" />
         </div>
       </div>
-
-      {/* Action bar — full-width bottom on mobile, centered pill on desktop */}
-      <div
-        className={
-          "pointer-events-auto fixed inset-x-0 bottom-0 z-30 flex flex-col gap-3 " +
-          "border-t border-border bg-popover p-4 text-popover-foreground shadow-2xl " +
-          "md:inset-x-auto md:right-auto md:bottom-6 md:left-1/2 md:-translate-x-1/2 " +
-          "md:flex-row md:items-center md:rounded-full md:border md:px-4 md:py-2"
-        }
-      >
-        <p className="text-sm md:max-w-xs md:text-center">
-          Drag the map to position the bullseye, then confirm.
-        </p>
-        <div className="flex gap-2 md:ml-2">
-          <Button
-            type="button"
-            variant="ghost"
-            onClick={handleCancel}
-            className="flex-1 gap-2 md:flex-none"
-          >
-            <X className="size-4" />
-            Cancel
-          </Button>
-          <Button type="button" onClick={handleConfirm} className="flex-1 gap-2 md:flex-none">
-            <Check className="size-4" />
-            Confirm location
-          </Button>
-        </div>
-      </div>
-    </>
+    </div>
   )
 }

--- a/src/components/panels/navigation/map-pick-overlay.tsx
+++ b/src/components/panels/navigation/map-pick-overlay.tsx
@@ -1,0 +1,84 @@
+import { Check, X } from "lucide-react"
+
+import { Button } from "#/components/ui/button"
+import { mapFromWorld } from "#/lib/coordinates"
+import { useMap } from "#/lib/map-context"
+import { useNavigation } from "#/lib/navigation-context"
+
+/**
+ * Overlay shown while the user is picking a start coordinate on the map.
+ *
+ * Two pieces:
+ * - Centered bullseye crosshair that the user pans the map under.
+ * - Bottom action bar containing the hint copy + Cancel / Confirm.
+ *   On mobile this fills the bottom edge (replacing the navigation panel,
+ *   which is hidden while picking). On desktop it's a centered pill.
+ *
+ * Confirm reads `OrbitControls.target` — the world point under viewport
+ * center — and writes it to the navigation context as `{ x, y, z, floor }`.
+ * Accurate in 2D top-down (the default). In 3D the target may not lie on
+ * the floor plane but it's still the camera's focal point — coarse but
+ * reasonable.
+ */
+export const MapPickOverlay = () => {
+  const { pickingStart, setPickingStart, controlsRef, currentFloor } = useMap()
+  const { setStart } = useNavigation()
+
+  if (!pickingStart) return null
+
+  const handleConfirm = () => {
+    const target = controlsRef.current?.target
+    if (!target || currentFloor === null) return
+    // OrbitControls.target is in three.js space; the navigation context
+    // stores picks in map coordinates so they share a shape with Node.
+    const map = mapFromWorld(target)
+    setStart({ x: map.x, y: map.y, floor: currentFloor })
+    setPickingStart(false)
+  }
+
+  const handleCancel = () => {
+    setPickingStart(false)
+  }
+
+  return (
+    <>
+      {/* Bullseye at viewport center */}
+      <div className="pointer-events-none absolute top-1/2 left-1/2 z-20 -translate-x-1/2 -translate-y-1/2">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/20 ring-2 ring-primary">
+          <div className="flex h-6 w-6 items-center justify-center rounded-full bg-primary/40 ring-2 ring-primary">
+            <div className="h-2 w-2 rounded-full bg-primary" />
+          </div>
+        </div>
+      </div>
+
+      {/* Action bar — full-width bottom on mobile, centered pill on desktop */}
+      <div
+        className={
+          "pointer-events-auto fixed inset-x-0 bottom-0 z-30 flex flex-col gap-3 " +
+          "border-t border-border bg-popover p-4 text-popover-foreground shadow-2xl " +
+          "md:inset-x-auto md:right-auto md:bottom-6 md:left-1/2 md:-translate-x-1/2 " +
+          "md:flex-row md:items-center md:rounded-full md:border md:px-4 md:py-2"
+        }
+      >
+        <p className="text-sm md:max-w-xs md:text-center">
+          Drag the map to position the bullseye, then confirm.
+        </p>
+        <div className="flex gap-2 md:ml-2">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={handleCancel}
+            className="flex-1 gap-2 md:flex-none"
+          >
+            <X className="size-4" />
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleConfirm} className="flex-1 gap-2 md:flex-none">
+            <Check className="size-4" />
+            Confirm location
+          </Button>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/components/panels/navigation/map-pick-overlay.tsx
+++ b/src/components/panels/navigation/map-pick-overlay.tsx
@@ -1,9 +1,12 @@
+import { CircleDot } from "lucide-react"
+
 import { useMap } from "#/lib/map-context"
 
 /**
- * Bullseye crosshair shown at viewport center while the user is picking a
- * start coordinate on the map. The accompanying Cancel / Confirm action bar
- * is owned by `<ActionBar />` (admin tools and pick-start share that shell).
+ * Crosshair shown at viewport center while the user is picking a start
+ * coordinate on the map. Uses the same `CircleDot` icon as the placed
+ * start marker, so the picking and placed states read as the same thing.
+ * The accompanying Cancel / Confirm action bar is owned by `<ActionBar />`.
  */
 export const MapPickOverlay = () => {
   const { pickingStart } = useMap()
@@ -12,11 +15,7 @@ export const MapPickOverlay = () => {
 
   return (
     <div className="pointer-events-none absolute top-1/2 left-1/2 z-20 -translate-x-1/2 -translate-y-1/2">
-      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/20 ring-2 ring-primary">
-        <div className="flex h-6 w-6 items-center justify-center rounded-full bg-primary/40 ring-2 ring-primary">
-          <div className="h-2 w-2 rounded-full bg-primary" />
-        </div>
-      </div>
+      <CircleDot className="size-9 text-blue-700 drop-shadow-lg" strokeWidth={2.5} />
     </div>
   )
 }

--- a/src/components/panels/navigation/navigation-panel-shared.tsx
+++ b/src/components/panels/navigation/navigation-panel-shared.tsx
@@ -1,10 +1,11 @@
 import { Accessibility, Circle, Crosshair, MapPin, Route, Zap } from "lucide-react"
 
 import type { SearchResultItem } from "#/components/ui/search-result-list"
+import type { FieldKey } from "#/lib/navigation-context"
 import type { RoutePreference } from "#/types/navigation"
 import type { LucideIcon } from "lucide-react"
 
-export type FieldKey = "start" | "destination"
+export type { FieldKey }
 
 export interface FieldConfig {
   key: FieldKey

--- a/src/components/panels/navigation/navigation-panel-shared.tsx
+++ b/src/components/panels/navigation/navigation-panel-shared.tsx
@@ -1,0 +1,68 @@
+ 
+import { Accessibility, Circle, Crosshair, MapPin, Route, Zap } from "lucide-react"
+
+import type { SearchResultItem } from "#/components/ui/search-result-list"
+import type { NavigationRequest } from "#/lib/navigation-context"
+import type { LucideIcon } from "lucide-react"
+
+export type FieldKey = "start" | "destination"
+
+export interface FieldConfig {
+  key: FieldKey
+  icon: LucideIcon
+  placeholder: string
+  ariaLabel: string
+}
+
+/** Fields rendered (in order) at the top of the navigation panel. */
+export const FIELDS: FieldConfig[] = [
+  { key: "start", icon: Circle, placeholder: "Choose start location", ariaLabel: "Start location" },
+  {
+    key: "destination",
+    icon: MapPin,
+    placeholder: "Search destination",
+    ariaLabel: "Destination",
+  },
+]
+
+/** Human-readable name for each field, used in headers and result captions. */
+export const FIELD_LABEL: Record<FieldKey, string> = {
+  start: "start location",
+  destination: "destination",
+}
+
+export interface PreferenceOption {
+  value: NavigationRequest["preference"]
+  label: string
+  icon: LucideIcon
+}
+
+/** Routing preference choices shown as a single-select toggle group. */
+export const PREFERENCE_OPTIONS: PreferenceOption[] = [
+  { value: "SIMPLE", label: "Simple", icon: Route },
+  { value: "FAST", label: "Fast", icon: Zap },
+  { value: "ACCESSIBLE", label: "Accessible", icon: Accessibility },
+]
+
+/** Static "pick a point on the floor plan" row shown above start results. */
+export const SELECT_ON_MAP_ITEM: SearchResultItem = {
+  id: "Select on map",
+  icon: <Crosshair className="w-5 h-5 text-white" />,
+  iconBgStyle: { backgroundColor: "var(--color-primary)" },
+  title: "",
+  type: "Pick a point on the floor plan",
+}
+
+/**
+ * Vertical 3-dot connector between the two field icons. Aligned to the
+ * leading-icon column of the SearchBar field variant (px-4 + half icon).
+ */
+export const DotConnector = () => (
+  <div className="flex pl-4 my-2.5">
+    <div className="flex w-5 flex-col items-center gap-1.5 py-0.5">
+      <div className="size-1 rounded-full bg-muted-foreground/60" />
+      <div className="size-1 rounded-full bg-muted-foreground/60" />
+      <div className="size-1 rounded-full bg-muted-foreground/60" />
+    </div>
+  </div>
+)

--- a/src/components/panels/navigation/navigation-panel-shared.tsx
+++ b/src/components/panels/navigation/navigation-panel-shared.tsx
@@ -1,8 +1,7 @@
- 
 import { Accessibility, Circle, Crosshair, MapPin, Route, Zap } from "lucide-react"
 
 import type { SearchResultItem } from "#/components/ui/search-result-list"
-import type { NavigationRequest } from "#/lib/navigation-context"
+import type { RoutePreference } from "#/types/navigation"
 import type { LucideIcon } from "lucide-react"
 
 export type FieldKey = "start" | "destination"
@@ -31,8 +30,8 @@ export const FIELD_LABEL: Record<FieldKey, string> = {
   destination: "destination",
 }
 
-export interface PreferenceOption {
-  value: NavigationRequest["preference"]
+interface PreferenceOption {
+  value: RoutePreference
   label: string
   icon: LucideIcon
 }

--- a/src/components/panels/navigation/navigation-panel.tsx
+++ b/src/components/panels/navigation/navigation-panel.tsx
@@ -1,43 +1,31 @@
-import { Circle, Crosshair, MapPin } from "lucide-react"
-import { useState } from "react"
+/* eslint-disable @typescript-eslint/naming-convention */
+import { Fragment, useState } from "react"
 
 import { useFuzzySearch } from "#/components/hooks/use-fuse"
+import {
+  DotConnector,
+  FIELD_LABEL,
+  FIELDS,
+  PREFERENCE_OPTIONS,
+  SELECT_ON_MAP_ITEM,
+  type FieldConfig,
+  type FieldKey,
+} from "#/components/panels/navigation/navigation-panel-shared"
 import { Panel } from "#/components/panels/panel"
 import { Button } from "#/components/ui/button"
 import { SearchBar } from "#/components/ui/search-bar"
 import { SearchResultList, type SearchResultItem } from "#/components/ui/search-result-list"
 import { Separator } from "#/components/ui/separator"
+import { ToggleGroup, ToggleGroupItem } from "#/components/ui/toggle-group"
+import { useMap } from "#/lib/map-context"
 import { useNavigation } from "#/lib/navigation-context"
-import { getRoomTypeMeta, getRoomTypeOutline } from "#/lib/room-types"
+import {
+  formatNavigationValue,
+  roomToSearchResultItem,
+  type RoomSearchResultItem,
+} from "#/lib/room-format"
 
 import type { NavigationRequest } from "#/lib/navigation-context"
-
-type FieldKey = "start" | "destination"
-
-type RoomResultItem = SearchResultItem & { dbId: string }
-
-const formatValue = (value: NavigationRequest["start"] | null) => {
-  if (!value) return ""
-  if ("roomNumber" in value) {
-    return value.displayName ? `${value.roomNumber} - ${value.displayName}` : value.roomNumber
-  }
-  if ("id" in value) return `Node ${value.id.slice(0, 6)}`
-  return `${value.x.toFixed(2)}, ${value.y.toFixed(2)} (floor ${value.floor})`
-}
-
-/**
- * Vertical 3-dot connector between the two field icons. Aligned to the
- * leading-icon column of the SearchBar field variant (px-4 + half icon).
- */
-const DotConnector = () => (
-  <div className="flex pl-4 my-2.5">
-    <div className="flex w-5 flex-col items-center gap-1.5 py-0.5">
-      <div className="size-1 rounded-full bg-muted-foreground/60" />
-      <div className="size-1 rounded-full bg-muted-foreground/60" />
-      <div className="size-1 rounded-full bg-muted-foreground/60" />
-    </div>
-  </div>
-)
 
 export const NavigationPanel = () => {
   const {
@@ -47,7 +35,10 @@ export const NavigationPanel = () => {
     setNavigationPanelOpen,
     setStart,
     setDestination,
+    preference,
+    setPreference,
   } = useNavigation()
+  const { pickingStart, setPickingStart } = useMap()
 
   const [activeField, setActiveField] = useState<FieldKey | null>(null)
   const [query, setQuery] = useState("")
@@ -59,51 +50,27 @@ export const NavigationPanel = () => {
   const [prevOpen, setPrevOpen] = useState(navigationPanelOpen)
   if (navigationPanelOpen !== prevOpen) {
     setPrevOpen(navigationPanelOpen)
-    if (navigationPanelOpen) {
-      setActiveField(destination !== null && start === null ? "start" : null)
-    } else {
-      setActiveField(null)
-    }
+    setActiveField(navigationPanelOpen && destination !== null && start === null ? "start" : null)
     setQuery("")
   }
 
-  const valueFor = (field: FieldKey) =>
-    activeField === field ? query : formatValue(field === "start" ? start : destination)
+  const fieldValue = (field: FieldKey) => (field === "start" ? start : destination)
+  const clearField = (field: FieldKey) => {
+    if (field === "start") setStart(null)
+    else setDestination(null)
+  }
 
   const focusField = (field: FieldKey) => {
     setActiveField(field)
     setQuery("")
   }
 
-  // Match FuzzySearchBar shape exactly — roomNumber as the displayed primary
-  // label, displayName as the secondary, plus a dbId attached for lookup.
-  const roomResults: RoomResultItem[] =
-    isLoading || activeField === null
-      ? []
-      : results.map((r) => {
-          const meta = getRoomTypeMeta(r.item.type)
-          const outline = getRoomTypeOutline(r.item.type)
-          const Icon = meta.icon
-          return {
-            id: r.item.roomNumber,
-            icon: <Icon className="w-5 h-5" style={{ color: outline }} />,
-            iconBgStyle: { backgroundColor: meta.color, outline: `2px solid ${outline}` },
-            title: r.item.displayName ?? "",
-            type: meta.label,
-            dbId: r.item.id,
-          }
-        })
-
-  const selectOnMapItem: SearchResultItem = {
-    id: "Select on map",
-    icon: <Crosshair className="w-5 h-5 text-white" />,
-    iconBgStyle: { backgroundColor: "var(--color-primary)" },
-    title: "",
-    type: "Pick a point on the floor plan",
-  }
+  const roomResults: RoomSearchResultItem[] =
+    isLoading || activeField === null ? [] : results.map((r) => roomToSearchResultItem(r.item))
 
   const handlePickRoom = (item: SearchResultItem) => {
-    const room = results.find((r) => r.item.roomNumber === item.id)?.item
+    const { dbId } = item as RoomSearchResultItem
+    const room = results.find((r) => r.item.id === dbId)?.item
     if (!room || !activeField) return
     if (activeField === "start") setStart(room)
     else setDestination(room)
@@ -112,26 +79,32 @@ export const NavigationPanel = () => {
   }
 
   const handleSelectOnMap = () => {
-    // TODO: enter map-pick mode for the start location.
-    console.log("Select on map: not yet implemented")
     setActiveField(null)
     setQuery("")
+    setPickingStart(true)
+  }
+
+  const handleClose = () => {
+    setNavigationPanelOpen(false)
+    setStart(null)
+    setDestination(null)
+    setActiveField(null)
+    setQuery("")
+    setPickingStart(false)
   }
 
   const canStart = start !== null && destination !== null
 
+  const headerText = (() => {
+    if (activeField !== null) return `Selecting ${FIELD_LABEL[activeField]} - pick a result below`
+    if (canStart) return "Ready to go"
+    return "Choose a start location and destination"
+  })()
+
   const header = (
     <div className="flex flex-col gap-1 p-5 pr-14">
       <h2 className="text-2xl font-bold">Navigation</h2>
-      <p className="text-sm text-popover-foreground/70">
-        {activeField === "start"
-          ? "Selecting start location — pick a result below"
-          : activeField === "destination"
-            ? "Selecting destination — pick a result below"
-            : canStart
-              ? "Ready to go"
-              : "Choose a start location and destination"}
-      </p>
+      <p className="text-sm text-popover-foreground/70">{headerText}</p>
     </div>
   )
 
@@ -143,66 +116,70 @@ export const NavigationPanel = () => {
     </div>
   )
 
+  const renderField = ({ key, icon: Icon, placeholder, ariaLabel }: FieldConfig) => {
+    const value = fieldValue(key)
+    const isActive = activeField === key
+    return (
+      <SearchBar
+        type="field"
+        leadingIcon={<Icon className="size-5 text-muted-foreground shrink-0" />}
+        placeholder={placeholder}
+        value={isActive ? query : formatNavigationValue(value)}
+        active={isActive}
+        onFocus={() => {
+          focusField(key)
+        }}
+        onQueryChange={setQuery}
+        onClear={
+          value !== null && !isActive
+            ? () => {
+                clearField(key)
+                setActiveField(key)
+                setQuery("")
+              }
+            : undefined
+        }
+        inputAriaLabel={ariaLabel}
+      />
+    )
+  }
+
+  const emptyResultsMessage =
+    query.trim().length === 0 ? "Start typing to search rooms" : "No matches"
+
   return (
     <Panel
-      open={navigationPanelOpen}
+      open={navigationPanelOpen && !pickingStart}
       fullHeight
-      onClose={() => {
-        setNavigationPanelOpen(false)
-        setStart(null)
-        setDestination(null)
-        setActiveField(null)
-        setQuery("")
-      }}
+      onClose={handleClose}
       header={header}
       footer={footer}
     >
       <div className="sticky top-0 z-10 flex flex-col gap-1 bg-popover px-4 pb-4">
-        <SearchBar
-          type="field"
-          leadingIcon={<Circle className="size-5 text-muted-foreground shrink-0" />}
-          placeholder="Choose start location"
-          value={valueFor("start")}
-          active={activeField === "start"}
-          onFocus={() => {
-            focusField("start")
-          }}
-          onQueryChange={setQuery}
-          onClear={
-            start !== null && activeField !== "start"
-              ? () => {
-                  setStart(null)
-                  setActiveField("start")
-                  setQuery("")
-                }
-              : undefined
-          }
-          inputAriaLabel="Start location"
-        />
+        {FIELDS.map((field, idx) => (
+          <Fragment key={field.key}>
+            {idx > 0 && <DotConnector />}
+            {renderField(field)}
+          </Fragment>
+        ))}
 
-        <DotConnector />
-
-        <SearchBar
-          type="field"
-          leadingIcon={<MapPin className="size-5 text-muted-foreground shrink-0" />}
-          placeholder="Search destination"
-          value={valueFor("destination")}
-          active={activeField === "destination"}
-          onFocus={() => {
-            focusField("destination")
+        <ToggleGroup
+          aria-label="Routing preference"
+          value={[preference]}
+          onValueChange={(next) => {
+            // Single-select: ignore the empty case (require one selected).
+            const [picked] = next
+            if (picked) setPreference(picked as NavigationRequest["preference"])
           }}
-          onQueryChange={setQuery}
-          onClear={
-            destination !== null && activeField !== "destination"
-              ? () => {
-                  setDestination(null)
-                  setActiveField("destination")
-                  setQuery("")
-                }
-              : undefined
-          }
-          inputAriaLabel="Destination"
-        />
+          className="mt-4 w-full [&>button]:flex-1"
+        >
+          {PREFERENCE_OPTIONS.map(({ value, label, icon: Icon }) => (
+            <ToggleGroupItem key={value} value={value} size="sm" aria-label={label}>
+              <Icon className="size-4" />
+              {label}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
       </div>
 
       {activeField !== null && (
@@ -210,13 +187,13 @@ export const NavigationPanel = () => {
           <Separator className="bg-white mx-4 my-2" />
           <div className="mx-2">
             <div className="py-2 text-xs font-medium uppercase tracking-wide text-primary-foreground">
-              Results for {activeField === "start" ? "start location" : "destination"}
+              Results for {FIELD_LABEL[activeField]}
             </div>
 
             {activeField === "start" && (
               <>
                 <SearchResultList
-                  items={[selectOnMapItem]}
+                  items={[SELECT_ON_MAP_ITEM]}
                   onItemClick={handleSelectOnMap}
                   bare
                   className="bg-white"
@@ -230,11 +207,11 @@ export const NavigationPanel = () => {
                 items={roomResults}
                 onItemClick={handlePickRoom}
                 bare
-                className="bg-white"
+                className="bg-white overflow-y-scroll"
               />
             ) : (
-              <div className="px-4 py-6 text-sm text-muted-foreground">
-                {query.trim().length === 0 ? "Start typing to search rooms" : "No matches"}
+              <div className="px-4 py-6 text-sm text-muted-foreground max-h-full">
+                {emptyResultsMessage}
               </div>
             )}
           </div>

--- a/src/components/panels/navigation/navigation-panel.tsx
+++ b/src/components/panels/navigation/navigation-panel.tsx
@@ -24,22 +24,8 @@ import {
   roomToSearchResultItem,
   type RoomSearchResultItem,
 } from "#/lib/room-format"
-import { polygonCentroid } from "#/lib/three-utils"
 
-import type { MapPickedPoint, RoutePreference } from "#/types/navigation"
-import type { Room } from "#/types/room"
-
-/**
- * Drop a pin at a room's centroid. Used when the user picks a room from the
- * start results — start must be a node or a free-form coordinate, not a room.
- *
- * Room vertices use the three.js floor-plane axes `(x, z)`; map coords use
- * `(x, y)` where `y = -z`, so the conversion flips the forward axis.
- */
-const roomToStartPoint = (room: Room): MapPickedPoint => {
-  const c = polygonCentroid(room.vertices)
-  return { x: c.x, y: -c.z, floor: room.floor }
-}
+import type { RoutePreference } from "#/types/navigation"
 
 export const NavigationPanel = () => {
   const {
@@ -51,10 +37,12 @@ export const NavigationPanel = () => {
     setDestination,
     preference,
     setPreference,
+    activeField,
+    setActiveField,
+    pickRoomForActiveField,
   } = useNavigation()
   const { pickingStart, setPickingStart } = useMap()
 
-  const [activeField, setActiveField] = useState<FieldKey | null>(null)
   const [query, setQuery] = useState("")
 
   const { results, isLoading } = useFuzzySearch(query)
@@ -85,15 +73,8 @@ export const NavigationPanel = () => {
   const handlePickRoom = (item: SearchResultItem) => {
     const { dbId } = item as RoomSearchResultItem
     const room = results.find((r) => r.item.id === dbId)?.item
-    if (!room || !activeField) return
-    if (activeField === "start") {
-      // A start must be a node or a free-form coordinate (not a room). When
-      // the user picks a room as a start, drop a pin at its centroid.
-      setStart(roomToStartPoint(room))
-    } else {
-      setDestination(room)
-    }
-    setActiveField(null)
+    if (!room) return
+    pickRoomForActiveField(room)
     setQuery("")
   }
 

--- a/src/components/panels/navigation/navigation-panel.tsx
+++ b/src/components/panels/navigation/navigation-panel.tsx
@@ -24,8 +24,22 @@ import {
   roomToSearchResultItem,
   type RoomSearchResultItem,
 } from "#/lib/room-format"
+import { polygonCentroid } from "#/lib/three-utils"
 
-import type { NavigationRequest } from "#/lib/navigation-context"
+import type { MapPickedPoint, RoutePreference } from "#/types/navigation"
+import type { Room } from "#/types/room"
+
+/**
+ * Drop a pin at a room's centroid. Used when the user picks a room from the
+ * start results — start must be a node or a free-form coordinate, not a room.
+ *
+ * Room vertices use the three.js floor-plane axes `(x, z)`; map coords use
+ * `(x, y)` where `y = -z`, so the conversion flips the forward axis.
+ */
+const roomToStartPoint = (room: Room): MapPickedPoint => {
+  const c = polygonCentroid(room.vertices)
+  return { x: c.x, y: -c.z, floor: room.floor }
+}
 
 export const NavigationPanel = () => {
   const {
@@ -72,8 +86,13 @@ export const NavigationPanel = () => {
     const { dbId } = item as RoomSearchResultItem
     const room = results.find((r) => r.item.id === dbId)?.item
     if (!room || !activeField) return
-    if (activeField === "start") setStart(room)
-    else setDestination(room)
+    if (activeField === "start") {
+      // A start must be a node or a free-form coordinate (not a room). When
+      // the user picks a room as a start, drop a pin at its centroid.
+      setStart(roomToStartPoint(room))
+    } else {
+      setDestination(room)
+    }
     setActiveField(null)
     setQuery("")
   }
@@ -169,7 +188,7 @@ export const NavigationPanel = () => {
           onValueChange={(next) => {
             // Single-select: ignore the empty case (require one selected).
             const [picked] = next
-            if (picked) setPreference(picked as NavigationRequest["preference"])
+            if (picked) setPreference(picked as RoutePreference)
           }}
           className="mt-4 w-full [&>button]:flex-1"
         >

--- a/src/components/panels/navigation/navigation-panel.tsx
+++ b/src/components/panels/navigation/navigation-panel.tsx
@@ -1,0 +1,245 @@
+import { Circle, Crosshair, MapPin } from "lucide-react"
+import { useState } from "react"
+
+import { useFuzzySearch } from "#/components/hooks/use-fuse"
+import { Panel } from "#/components/panels/panel"
+import { Button } from "#/components/ui/button"
+import { SearchBar } from "#/components/ui/search-bar"
+import { SearchResultList, type SearchResultItem } from "#/components/ui/search-result-list"
+import { Separator } from "#/components/ui/separator"
+import { useNavigation } from "#/lib/navigation-context"
+import { getRoomTypeMeta, getRoomTypeOutline } from "#/lib/room-types"
+
+import type { NavigationRequest } from "#/lib/navigation-context"
+
+type FieldKey = "start" | "destination"
+
+type RoomResultItem = SearchResultItem & { dbId: string }
+
+const formatValue = (value: NavigationRequest["start"] | null) => {
+  if (!value) return ""
+  if ("roomNumber" in value) {
+    return value.displayName ? `${value.roomNumber} - ${value.displayName}` : value.roomNumber
+  }
+  if ("id" in value) return `Node ${value.id.slice(0, 6)}`
+  return `${value.x.toFixed(2)}, ${value.y.toFixed(2)} (floor ${value.floor})`
+}
+
+/**
+ * Vertical 3-dot connector between the two field icons. Aligned to the
+ * leading-icon column of the SearchBar field variant (px-4 + half icon).
+ */
+const DotConnector = () => (
+  <div className="flex pl-4 my-2.5">
+    <div className="flex w-5 flex-col items-center gap-1.5 py-0.5">
+      <div className="size-1 rounded-full bg-muted-foreground/60" />
+      <div className="size-1 rounded-full bg-muted-foreground/60" />
+      <div className="size-1 rounded-full bg-muted-foreground/60" />
+    </div>
+  </div>
+)
+
+export const NavigationPanel = () => {
+  const {
+    start,
+    destination,
+    navigationPanelOpen,
+    setNavigationPanelOpen,
+    setStart,
+    setDestination,
+  } = useNavigation()
+
+  const [activeField, setActiveField] = useState<FieldKey | null>(null)
+  const [query, setQuery] = useState("")
+
+  const { results, isLoading } = useFuzzySearch(query)
+
+  // React to the open prop transitioning. Derived-state pattern (same as
+  // Panel's height reset) — no effect needed.
+  const [prevOpen, setPrevOpen] = useState(navigationPanelOpen)
+  if (navigationPanelOpen !== prevOpen) {
+    setPrevOpen(navigationPanelOpen)
+    if (navigationPanelOpen) {
+      setActiveField(destination !== null && start === null ? "start" : null)
+    } else {
+      setActiveField(null)
+    }
+    setQuery("")
+  }
+
+  const valueFor = (field: FieldKey) =>
+    activeField === field ? query : formatValue(field === "start" ? start : destination)
+
+  const focusField = (field: FieldKey) => {
+    setActiveField(field)
+    setQuery("")
+  }
+
+  // Match FuzzySearchBar shape exactly — roomNumber as the displayed primary
+  // label, displayName as the secondary, plus a dbId attached for lookup.
+  const roomResults: RoomResultItem[] =
+    isLoading || activeField === null
+      ? []
+      : results.map((r) => {
+          const meta = getRoomTypeMeta(r.item.type)
+          const outline = getRoomTypeOutline(r.item.type)
+          const Icon = meta.icon
+          return {
+            id: r.item.roomNumber,
+            icon: <Icon className="w-5 h-5" style={{ color: outline }} />,
+            iconBgStyle: { backgroundColor: meta.color, outline: `2px solid ${outline}` },
+            title: r.item.displayName ?? "",
+            type: meta.label,
+            dbId: r.item.id,
+          }
+        })
+
+  const selectOnMapItem: SearchResultItem = {
+    id: "Select on map",
+    icon: <Crosshair className="w-5 h-5 text-white" />,
+    iconBgStyle: { backgroundColor: "var(--color-primary)" },
+    title: "",
+    type: "Pick a point on the floor plan",
+  }
+
+  const handlePickRoom = (item: SearchResultItem) => {
+    const room = results.find((r) => r.item.roomNumber === item.id)?.item
+    if (!room || !activeField) return
+    if (activeField === "start") setStart(room)
+    else setDestination(room)
+    setActiveField(null)
+    setQuery("")
+  }
+
+  const handleSelectOnMap = () => {
+    // TODO: enter map-pick mode for the start location.
+    console.log("Select on map: not yet implemented")
+    setActiveField(null)
+    setQuery("")
+  }
+
+  const canStart = start !== null && destination !== null
+
+  const header = (
+    <div className="flex flex-col gap-1 p-5 pr-14">
+      <h2 className="text-2xl font-bold">Navigation</h2>
+      <p className="text-sm text-popover-foreground/70">
+        {activeField === "start"
+          ? "Selecting start location — pick a result below"
+          : activeField === "destination"
+            ? "Selecting destination — pick a result below"
+            : canStart
+              ? "Ready to go"
+              : "Choose a start location and destination"}
+      </p>
+    </div>
+  )
+
+  const footer = (
+    <div className="border-t border-white/10 p-4">
+      <Button type="button" className="w-full" disabled={!canStart}>
+        Start
+      </Button>
+    </div>
+  )
+
+  return (
+    <Panel
+      open={navigationPanelOpen}
+      fullHeight
+      onClose={() => {
+        setNavigationPanelOpen(false)
+        setStart(null)
+        setDestination(null)
+        setActiveField(null)
+        setQuery("")
+      }}
+      header={header}
+      footer={footer}
+    >
+      <div className="sticky top-0 z-10 flex flex-col gap-1 bg-popover px-4 pb-4">
+        <SearchBar
+          type="field"
+          leadingIcon={<Circle className="size-5 text-muted-foreground shrink-0" />}
+          placeholder="Choose start location"
+          value={valueFor("start")}
+          active={activeField === "start"}
+          onFocus={() => {
+            focusField("start")
+          }}
+          onQueryChange={setQuery}
+          onClear={
+            start !== null && activeField !== "start"
+              ? () => {
+                  setStart(null)
+                  setActiveField("start")
+                  setQuery("")
+                }
+              : undefined
+          }
+          inputAriaLabel="Start location"
+        />
+
+        <DotConnector />
+
+        <SearchBar
+          type="field"
+          leadingIcon={<MapPin className="size-5 text-muted-foreground shrink-0" />}
+          placeholder="Search destination"
+          value={valueFor("destination")}
+          active={activeField === "destination"}
+          onFocus={() => {
+            focusField("destination")
+          }}
+          onQueryChange={setQuery}
+          onClear={
+            destination !== null && activeField !== "destination"
+              ? () => {
+                  setDestination(null)
+                  setActiveField("destination")
+                  setQuery("")
+                }
+              : undefined
+          }
+          inputAriaLabel="Destination"
+        />
+      </div>
+
+      {activeField !== null && (
+        <>
+          <Separator className="bg-white mx-4 my-2" />
+          <div className="mx-2">
+            <div className="py-2 text-xs font-medium uppercase tracking-wide text-primary-foreground">
+              Results for {activeField === "start" ? "start location" : "destination"}
+            </div>
+
+            {activeField === "start" && (
+              <>
+                <SearchResultList
+                  items={[selectOnMapItem]}
+                  onItemClick={handleSelectOnMap}
+                  bare
+                  className="bg-white"
+                />
+                <Separator />
+              </>
+            )}
+
+            {roomResults.length > 0 ? (
+              <SearchResultList
+                items={roomResults}
+                onItemClick={handlePickRoom}
+                bare
+                className="bg-white"
+              />
+            ) : (
+              <div className="px-4 py-6 text-sm text-muted-foreground">
+                {query.trim().length === 0 ? "Start typing to search rooms" : "No matches"}
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </Panel>
+  )
+}

--- a/src/components/panels/node/node-create-panel.tsx
+++ b/src/components/panels/node/node-create-panel.tsx
@@ -236,10 +236,7 @@ export const NodeCreatePanel = () => {
         )}
       </form.Field>
 
-      <DetailRow
-        label="Room"
-        value={linkedRoom ? formatRoomLabel(linkedRoom) : "None"}
-      />
+      <DetailRow label="Room" value={linkedRoom ? formatRoomLabel(linkedRoom) : "None"} />
 
       <form.Field name="isActivated">
         {(field) => (

--- a/src/components/panels/node/node-create-panel.tsx
+++ b/src/components/panels/node/node-create-panel.tsx
@@ -16,6 +16,7 @@ import { Button } from "#/components/ui/button"
 import { Label } from "#/components/ui/label"
 import { Switch } from "#/components/ui/switch"
 import { useMap } from "#/lib/map-context"
+import { formatRoomLabel } from "#/lib/room-format"
 import { cn } from "#/lib/utils"
 import { addNodeData, createTransitNodesData } from "#/server/graph.functions"
 import { getAllRoomsData } from "#/server/room.functions"
@@ -237,7 +238,7 @@ export const NodeCreatePanel = () => {
 
       <DetailRow
         label="Room"
-        value={linkedRoom ? `${linkedRoom.roomNumber} · ${linkedRoom.displayName}` : "None"}
+        value={linkedRoom ? formatRoomLabel(linkedRoom) : "None"}
       />
 
       <form.Field name="isActivated">

--- a/src/components/panels/node/node-edit-panel.tsx
+++ b/src/components/panels/node/node-edit-panel.tsx
@@ -327,10 +327,7 @@ export const NodeEditPanel = ({ nodeId }: NodeEditPanelProps) => {
             disabled={activateMutation.isPending}
           />
         </div>
-        <DetailRow
-          label="Room"
-          value={linkedRoom ? formatRoomLabel(linkedRoom) : "None"}
-        />
+        <DetailRow label="Room" value={linkedRoom ? formatRoomLabel(linkedRoom) : "None"} />
       </div>
 
       <form.Field name="type">

--- a/src/components/panels/node/node-edit-panel.tsx
+++ b/src/components/panels/node/node-edit-panel.tsx
@@ -18,6 +18,7 @@ import { Button } from "#/components/ui/button"
 import { Label } from "#/components/ui/label"
 import { Switch } from "#/components/ui/switch"
 import { useMap } from "#/lib/map-context"
+import { formatRoomLabel } from "#/lib/room-format"
 import { cn } from "#/lib/utils"
 import {
   activateNodeData,
@@ -328,7 +329,7 @@ export const NodeEditPanel = ({ nodeId }: NodeEditPanelProps) => {
         </div>
         <DetailRow
           label="Room"
-          value={linkedRoom ? `${linkedRoom.roomNumber} · ${linkedRoom.displayName}` : "None"}
+          value={linkedRoom ? formatRoomLabel(linkedRoom) : "None"}
         />
       </div>
 

--- a/src/components/panels/node/node-panel-shared.tsx
+++ b/src/components/panels/node/node-panel-shared.tsx
@@ -19,7 +19,7 @@ export const NODE_TYPE_LABELS: Record<string, string> = {
   ENDPOINT: "Endpoint",
 }
 
-export const NODE_TYPES: NodeType[] = ["DEFAULT", "DOOR", "STAIR", "ELEVATOR", "ENDPOINT"]
+const NODE_TYPES: NodeType[] = ["DEFAULT", "DOOR", "STAIR", "ELEVATOR", "ENDPOINT"]
 export const TRANSIT_TYPES = new Set<NodeType>(["STAIR", "ELEVATOR"])
 export const FLOOR_HEIGHT_METERS = 3.25
 
@@ -30,7 +30,7 @@ export const PanelTitle = ({ title, subtitle }: { title: string; subtitle: strin
   </div>
 )
 
-export const FieldWrapper = ({
+const FieldWrapper = ({
   htmlFor,
   label,
   error,

--- a/src/components/panels/panel.tsx
+++ b/src/components/panels/panel.tsx
@@ -21,10 +21,10 @@ interface PanelProps {
   /** Called when the user clicks the built-in close button. Omit to hide it. */
   onClose?: () => void
   /**
-   * When true, the panel always fills the entire viewport height — no drag
-   * handle, no collapsed/expanded snaps. The body scrolls if it overflows.
-   * Use for panels (like navigation) where partial height adds friction
-   * rather than discoverability.
+   * Mobile only: when true, the bottom sheet opens at its expanded snap
+   * (full content / 92dvh cap) instead of the default header-only snap.
+   * The drag handle is still available so the user can swipe down to a
+   * header-only minimum either way. Desktop is always full-height.
    */
   fullHeight?: boolean
 }
@@ -35,13 +35,14 @@ interface PanelProps {
  * Layout (header + body + footer always rendered in that order):
  * - **Desktop (≥ md):** anchored to the right edge, full viewport height.
  *   Header pinned top, footer pinned bottom, body scrolls if it overflows.
- * - **Mobile (< md):** bottom sheet. Collapsed by default to just header +
- *   footer (body hidden). Drag the handle up to grow toward the natural
- *   content height; if content exceeds 92dvh the sheet caps there and the
- *   body scrolls.
- *
- * Snap points: collapsed (header + footer only) and expanded (full content,
- * up to the viewport cap). Releasing the drag picks the nearest.
+ * - **Mobile (< md):** bottom sheet with two snap points:
+ *   - **collapsed**: handle + header + footer (body hidden). Always shows
+ *     the title and the primary action.
+ *   - **expanded**: natural content height, capped at 92dvh; or the full
+ *     viewport when `fullHeight`.
+ *   Drag the handle to move between them; release picks the nearest snap.
+ *   `fullHeight` controls which snap the sheet opens at — collapsed by
+ *   default, expanded when set.
  */
 export const Panel = ({
   open,
@@ -57,8 +58,13 @@ export const Panel = ({
   const footerRef = useRef<HTMLDivElement>(null)
   const bodyRef = useRef<HTMLDivElement>(null)
 
-  const [chromePx, setChromePx] = useState(0)
+  const [handlePx, setHandlePx] = useState(0)
+  const [headerPx, setHeaderPx] = useState(0)
+  const [footerPx, setFooterPx] = useState(0)
   const [contentPx, setContentPx] = useState(0)
+  const [viewportPx, setViewportPx] = useState(() =>
+    typeof globalThis.innerHeight === "number" ? globalThis.innerHeight : 0,
+  )
   const [heightPx, setHeightPx] = useState<number | null>(null)
   const [dragging, setDragging] = useState(false)
   const [prevOpen, setPrevOpen] = useState(open)
@@ -66,12 +72,10 @@ export const Panel = ({
 
   useLayoutEffect(() => {
     const measure = () => {
-      const handleH = handleRef.current?.offsetHeight ?? 0
-      const headerH = headerRef.current?.offsetHeight ?? 0
-      const footerH = footerRef.current?.offsetHeight ?? 0
-      const contentH = bodyRef.current?.scrollHeight ?? 0
-      setChromePx(handleH + headerH + footerH)
-      setContentPx(contentH)
+      setHandlePx(handleRef.current?.offsetHeight ?? 0)
+      setHeaderPx(headerRef.current?.offsetHeight ?? 0)
+      setFooterPx(footerRef.current?.offsetHeight ?? 0)
+      setContentPx(bodyRef.current?.scrollHeight ?? 0)
     }
     measure()
     const ro = new ResizeObserver(measure)
@@ -84,20 +88,36 @@ export const Panel = ({
     }
   }, [header, footer, children])
 
-  const maxPx =
-    typeof globalThis.innerHeight === "number" ? (globalThis.innerHeight * MAX_HEIGHT_DVH) / 100 : 0
-  const collapsedPx = chromePx
-  const expandedPx = Math.min(chromePx + contentPx, maxPx)
+  useLayoutEffect(() => {
+    const update = () => {
+      setViewportPx(window.innerHeight)
+    }
+    update()
+    window.addEventListener("resize", update)
+    return () => {
+      window.removeEventListener("resize", update)
+    }
+  }, [])
+
+  const maxPx = (viewportPx * MAX_HEIGHT_DVH) / 100
+  // Snap points: collapsed (chrome only — title + primary action stay visible)
+  // and expanded (natural content height capped at 92dvh, or the full cap for
+  // fullHeight panels).
+  const collapsedPx = handlePx + headerPx + footerPx
+  const naturalPx = collapsedPx + contentPx
+  const expandedPx = fullHeight ? maxPx : Math.min(naturalPx, maxPx)
   const snapMidPx = (collapsedPx + expandedPx) / 2
 
-  // Reset to collapsed each time the sheet re-opens (derived-state pattern).
+  // On open, clear any drag-locked height so the live default snap (driven
+  // by the fallback below) takes over. Releases stale measurements that
+  // would otherwise capture a 0-height footer before it had a chance to
+  // mount. (Derived-state pattern — runs during render, no effect.)
   if (open !== prevOpen) {
     setPrevOpen(open)
     if (open) setHeightPx(null)
   }
 
-  const currentHeight = heightPx ?? collapsedPx
-  const useDragSheet = isMobile && !fullHeight
+  const currentHeight = heightPx ?? (fullHeight ? expandedPx : collapsedPx)
 
   const handlePointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
     dragRef.current = { startY: e.clientY, startHeight: currentHeight }
@@ -123,13 +143,13 @@ export const Panel = ({
   return (
     <aside
       aria-hidden={!open}
-      style={useDragSheet ? { height: `${currentHeight}px` } : undefined}
+      style={isMobile ? { height: `${currentHeight}px` } : undefined}
       className={cn(
         "fixed z-30 flex flex-col overflow-hidden bg-popover text-popover-foreground shadow-2xl",
         "transition-transform duration-300 ease-in-out",
         !dragging && "transition-[transform,height]",
-        // mobile shape — drag-sheet anchors to the bottom; full-height covers the viewport
-        useDragSheet ? "inset-x-0 bottom-0 rounded-t-2xl border-t border-border" : "inset-0",
+        // mobile: bottom sheet
+        "inset-x-0 bottom-0 rounded-t-2xl border-t border-border",
         // desktop: right-anchored full-height (overrides the mobile shape)
         "md:inset-x-auto md:bottom-auto md:top-0 md:right-0 md:h-full md:w-88 md:rounded-none md:border-l",
         open
@@ -137,18 +157,16 @@ export const Panel = ({
           : "pointer-events-none translate-y-full md:translate-y-0 md:translate-x-full",
       )}
     >
-      {useDragSheet && (
-        <div
-          ref={handleRef}
-          className="flex shrink-0 cursor-grab touch-none items-center justify-center py-2 active:cursor-grabbing md:hidden"
-          onPointerDown={handlePointerDown}
-          onPointerMove={handlePointerMove}
-          onPointerUp={handlePointerUp}
-          onPointerCancel={handlePointerUp}
-        >
-          <div className="h-1.5 w-12 rounded-full bg-muted-foreground/30" />
-        </div>
-      )}
+      <div
+        ref={handleRef}
+        className="flex shrink-0 cursor-grab touch-none items-center justify-center py-2 active:cursor-grabbing md:hidden"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+      >
+        <div className="h-1.5 w-12 rounded-full bg-muted-foreground/30" />
+      </div>
       <div ref={headerRef} className="relative shrink-0">
         {header}
         {onClose && (
@@ -168,10 +186,10 @@ export const Panel = ({
         ref={bodyRef}
         className={cn(
           "min-h-0 flex-1",
-          // Only enable scroll when the visible body area is actually shorter
-          // than its content. Otherwise touch jitter can scroll a panel that
-          // already fits perfectly.
-          useDragSheet && currentHeight - chromePx >= contentPx
+          // On mobile, only enable scroll when the visible body area is
+          // actually shorter than its content. Otherwise touch jitter can
+          // scroll a panel that already fits perfectly.
+          isMobile && currentHeight - (handlePx + headerPx + footerPx) >= contentPx
             ? "overflow-hidden"
             : "overflow-y-auto",
         )}

--- a/src/components/panels/panel.tsx
+++ b/src/components/panels/panel.tsx
@@ -20,6 +20,13 @@ interface PanelProps {
   children: ReactNode
   /** Called when the user clicks the built-in close button. Omit to hide it. */
   onClose?: () => void
+  /**
+   * When true, the panel always fills the entire viewport height — no drag
+   * handle, no collapsed/expanded snaps. The body scrolls if it overflows.
+   * Use for panels (like navigation) where partial height adds friction
+   * rather than discoverability.
+   */
+  fullHeight?: boolean
 }
 
 /**
@@ -36,7 +43,14 @@ interface PanelProps {
  * Snap points: collapsed (header + footer only) and expanded (full content,
  * up to the viewport cap). Releasing the drag picks the nearest.
  */
-export const Panel = ({ open, header, footer, children, onClose }: PanelProps) => {
+export const Panel = ({
+  open,
+  header,
+  footer,
+  children,
+  onClose,
+  fullHeight = false,
+}: PanelProps) => {
   const isMobile = useIsMobile()
   const handleRef = useRef<HTMLDivElement>(null)
   const headerRef = useRef<HTMLDivElement>(null)
@@ -83,6 +97,7 @@ export const Panel = ({ open, header, footer, children, onClose }: PanelProps) =
   }
 
   const currentHeight = heightPx ?? collapsedPx
+  const useDragSheet = isMobile && !fullHeight
 
   const handlePointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
     dragRef.current = { startY: e.clientY, startHeight: currentHeight }
@@ -108,30 +123,32 @@ export const Panel = ({ open, header, footer, children, onClose }: PanelProps) =
   return (
     <aside
       aria-hidden={!open}
-      style={isMobile ? { height: `${currentHeight}px` } : undefined}
+      style={useDragSheet ? { height: `${currentHeight}px` } : undefined}
       className={cn(
         "fixed z-30 flex flex-col overflow-hidden bg-popover text-popover-foreground shadow-2xl",
         "transition-transform duration-300 ease-in-out",
         !dragging && "transition-[transform,height]",
-        // mobile: bottom sheet
-        "inset-x-0 bottom-0 rounded-t-2xl border-t border-border",
-        // desktop: right-anchored full-height
-        "md:inset-x-auto md:bottom-auto md:top-0 md:right-0 md:h-full md:w-88 md:rounded-t-none md:border-t-0 md:border-l",
+        // mobile shape — drag-sheet anchors to the bottom; full-height covers the viewport
+        useDragSheet ? "inset-x-0 bottom-0 rounded-t-2xl border-t border-border" : "inset-0",
+        // desktop: right-anchored full-height (overrides the mobile shape)
+        "md:inset-x-auto md:bottom-auto md:top-0 md:right-0 md:h-full md:w-88 md:rounded-none md:border-l",
         open
           ? "translate-y-0 md:translate-x-0"
           : "pointer-events-none translate-y-full md:translate-y-0 md:translate-x-full",
       )}
     >
-      <div
-        ref={handleRef}
-        className="flex shrink-0 cursor-grab touch-none items-center justify-center py-2 active:cursor-grabbing md:hidden"
-        onPointerDown={handlePointerDown}
-        onPointerMove={handlePointerMove}
-        onPointerUp={handlePointerUp}
-        onPointerCancel={handlePointerUp}
-      >
-        <div className="h-1.5 w-12 rounded-full bg-muted-foreground/30" />
-      </div>
+      {useDragSheet && (
+        <div
+          ref={handleRef}
+          className="flex shrink-0 cursor-grab touch-none items-center justify-center py-2 active:cursor-grabbing md:hidden"
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerUp}
+        >
+          <div className="h-1.5 w-12 rounded-full bg-muted-foreground/30" />
+        </div>
+      )}
       <div ref={headerRef} className="relative shrink-0">
         {header}
         {onClose && (
@@ -154,7 +171,9 @@ export const Panel = ({ open, header, footer, children, onClose }: PanelProps) =
           // Only enable scroll when the visible body area is actually shorter
           // than its content. Otherwise touch jitter can scroll a panel that
           // already fits perfectly.
-          isMobile && currentHeight - chromePx >= contentPx ? "overflow-hidden" : "overflow-y-auto",
+          useDragSheet && currentHeight - chromePx >= contentPx
+            ? "overflow-hidden"
+            : "overflow-y-auto",
         )}
       >
         {children}

--- a/src/components/panels/room/room-edit-panel.tsx
+++ b/src/components/panels/room/room-edit-panel.tsx
@@ -17,10 +17,10 @@ import { Button } from "#/components/ui/button"
 import { useMap } from "#/lib/map-context"
 import { deleteRoomData, updateRoomMetadataData } from "#/server/room.functions"
 
-import type { PersistedRoom } from "#/server/room.server"
+import type { Room } from "#/types/room"
 
 interface RoomEditPanelProps {
-  room: PersistedRoom
+  room: Room
 }
 
 /**
@@ -59,7 +59,8 @@ export const RoomEditPanel = ({ room }: RoomEditPanelProps) => {
   const form = useForm({
     defaultValues: {
       roomNumber: room.roomNumber,
-      displayName: room.displayName,
+      // Form internals use `string | undefined` for unset; the DB stores `null`.
+      displayName: room.displayName ?? undefined,
       type: room.type,
     },
     onSubmit: async ({ value }) => {

--- a/src/components/panels/room/room-info-panel.tsx
+++ b/src/components/panels/room/room-info-panel.tsx
@@ -8,16 +8,16 @@ import { useMap } from "#/lib/map-context"
 import { useNavigation } from "#/lib/navigation-context"
 import { getAllRoomsData } from "#/server/room.functions"
 
-import type { PersistedRoom } from "#/server/room.server"
+import type { Room } from "#/types/room"
 import type { ReactNode } from "react"
 
 /**
- * PersistedRoom today only has `roomNumber/displayName/type/floor/vertices`,
- * but the UI contract the user is designing to includes an address, faculty,
- * and department. The panel reads them optionally so the view works now and
+ * `Room` today only has `roomNumber/displayName/type/floor/vertices`, but the
+ * UI contract the user is designing to includes an address, faculty, and
+ * department. The panel reads them optionally so the view works now and
  * lights up automatically when the schema gains them.
  */
-type RoomView = PersistedRoom & {
+type RoomView = Room & {
   address?: string
   faculty?: string
   department?: string

--- a/src/components/panels/room/room-info-panel.tsx
+++ b/src/components/panels/room/room-info-panel.tsx
@@ -5,6 +5,7 @@ import { Panel } from "#/components/panels/panel"
 import { Button } from "#/components/ui/button"
 import { RoomTypeBadge } from "#/components/ui/room-type-badge"
 import { useMap } from "#/lib/map-context"
+import { useNavigation } from "#/lib/navigation-context"
 import { getAllRoomsData } from "#/server/room.functions"
 
 import type { PersistedRoom } from "#/server/room.server"
@@ -56,9 +57,9 @@ const RoomInfoBody = ({ room }: { room: RoomView }) => (
   </div>
 )
 
-const RoomInfoFooter = () => (
+const RoomInfoFooter = ({ onStart }: { onStart: () => void }) => (
   <div className="flex flex-col gap-2 border-t border-white/10 p-5">
-    <Button type="button" className="gap-2">
+    <Button type="button" className="gap-2" onClick={onStart}>
       <NavigationIcon className="size-4" />
       Start navigation
     </Button>
@@ -74,6 +75,7 @@ const RoomInfoFooter = () => (
  */
 export const RoomInfoPanel = () => {
   const { viewingRoomId, setViewingRoomId } = useMap()
+  const { setDestination, setNavigationPanelOpen } = useNavigation()
 
   const { data: rooms = [] } = useQuery({
     queryKey: ["rooms"],
@@ -84,6 +86,13 @@ export const RoomInfoPanel = () => {
 
   const open = room != null
 
+  const handleStart = () => {
+    if (!room) return
+    setDestination(room)
+    setViewingRoomId(null)
+    setNavigationPanelOpen(true)
+  }
+
   return (
     <Panel
       open={open}
@@ -91,7 +100,7 @@ export const RoomInfoPanel = () => {
         setViewingRoomId(null)
       }}
       header={room && <RoomInfoHeader room={room} />}
-      footer={<RoomInfoFooter />}
+      footer={<RoomInfoFooter onStart={handleStart} />}
     >
       {room && <RoomInfoBody room={room} />}
     </Panel>

--- a/src/components/panels/room/room-panel-shared.tsx
+++ b/src/components/panels/room/room-panel-shared.tsx
@@ -36,7 +36,7 @@ interface FieldWrapperProps {
   children: ReactNode
 }
 
-export const FieldWrapper = ({ htmlFor, label, error, children }: FieldWrapperProps) => (
+const FieldWrapper = ({ htmlFor, label, error, children }: FieldWrapperProps) => (
   <div className="flex flex-col gap-1.5">
     <Label htmlFor={htmlFor}>{label}</Label>
     {children}

--- a/src/components/threeJS/connect-edge-layer.tsx
+++ b/src/components/threeJS/connect-edge-layer.tsx
@@ -5,11 +5,11 @@ import { useCallback, useMemo, useRef, useState } from "react"
 import * as THREE from "three"
 
 import { useMap } from "#/lib/map-context"
+import { lift, mapPointToThree } from "#/lib/three-utils"
 import { addEdgeData, getAllEdgesData, getAllNodesData } from "#/server/graph.functions"
 
 import { useCanvasPointer } from "../hooks/use-canvas-pointer"
 
-import { DRAWING_LIFT, FLOOR_HEIGHT } from "./constants"
 import { EdgePreview, VertexMarker } from "./draw-primitives"
 import { RaycastPlane } from "./raycast-plane"
 
@@ -38,15 +38,7 @@ type EdgeRecord = Awaited<ReturnType<typeof getAllEdgesData>>[number]
 
 // Clickable node sphere, selects as edge source or target
 
-const ClickableNodeForEdge = ({
-  node,
-  floorY,
-  color,
-}: {
-  node: NodeRecord
-  floorY: number
-  color: string
-}) => {
+const ClickableNodeForEdge = ({ node, color }: { node: NodeRecord; color: string }) => {
   const { pendingEdgeFromNodeId, setPendingEdgeFromNodeId, setEditingEdgeId } = useMap()
   const queryClient = useQueryClient()
   const meshRef = useRef<THREE.Mesh>(null)
@@ -104,7 +96,7 @@ const ClickableNodeForEdge = ({
   return (
     <mesh
       ref={meshRef}
-      position={[node.x, floorY + DRAWING_LIFT, -node.y]}
+      position={mapPointToThree(node)}
       onPointerDown={(e) => {
         e.stopPropagation()
         downRef.current = { x: e.clientX, y: e.clientY }
@@ -140,14 +132,8 @@ const ClickableEdge = ({
   const { setEditingEdgeId, setPendingEdgeFromNodeId } = useMap()
   const downRef = useRef<{ x: number; y: number } | null>(null)
 
-  const fromY = fromNode.floor * FLOOR_HEIGHT + DRAWING_LIFT
-  const toY = toNode.floor * FLOOR_HEIGHT + DRAWING_LIFT
-
-  const from3D = useMemo(
-    () => new THREE.Vector3(fromNode.x, fromY, -fromNode.y),
-    [fromNode.x, fromNode.y, fromY],
-  )
-  const to3D = useMemo(() => new THREE.Vector3(toNode.x, toY, -toNode.y), [toNode.x, toNode.y, toY])
+  const from3D = useMemo(() => new THREE.Vector3(...mapPointToThree(fromNode)), [fromNode])
+  const to3D = useMemo(() => new THREE.Vector3(...mapPointToThree(toNode)), [toNode])
 
   const { mid, length, quaternion } = useMemo(() => {
     const m = new THREE.Vector3().addVectors(from3D, to3D).multiplyScalar(0.5)
@@ -204,8 +190,6 @@ export const ConnectEdgeLayer = ({ floor }: ConnectEdgeLayerProps) => {
   const { pendingEdgeFromNodeId, editingEdgeId, setPendingEdgeFromNodeId, setEditingEdgeId } =
     useMap()
   const [cursor, setCursor] = useState<THREE.Vector3 | null>(null)
-
-  const floorY = floor.floor * FLOOR_HEIGHT
 
   const { data: allNodes = [] } = useQuery({
     queryKey: ["nodes"],
@@ -299,16 +283,13 @@ export const ConnectEdgeLayer = ({ floor }: ConnectEdgeLayerProps) => {
       })}
 
       {floorNodes.map((node) => (
-        <ClickableNodeForEdge key={node.id} node={node} floorY={floorY} color={nodeColor(node)} />
+        <ClickableNodeForEdge key={node.id} node={node} color={nodeColor(node)} />
       ))}
 
       {/* Preview line from source node to cursor */}
       {sourceNode && cursor && (
         <EdgePreview
-          points={[
-            [sourceNode.x, floorY + DRAWING_LIFT, -sourceNode.y],
-            [cursor.x, floorY + DRAWING_LIFT, cursor.z],
-          ]}
+          points={[mapPointToThree(sourceNode), lift(cursor)]}
           color={EDGE_PREVIEW_COLOR}
           lineWidth={2}
         />
@@ -317,7 +298,7 @@ export const ConnectEdgeLayer = ({ floor }: ConnectEdgeLayerProps) => {
       {/* Halo on source node */}
       {sourceNode && (
         <VertexMarker
-          position={[sourceNode.x, floorY + DRAWING_LIFT, -sourceNode.y]}
+          position={mapPointToThree(sourceNode)}
           color={NODE_HIGHLIGHT_COLOR}
           radius={0.22}
         />

--- a/src/components/threeJS/constants.ts
+++ b/src/components/threeJS/constants.ts
@@ -13,9 +13,6 @@ export const TILT_FADE_END = Math.PI / 4 // 45°
 /** Maximum opacity for non-active floor plans when tilted */
 export const NEIGHBOUR_MAX_OPACITY = 0.2
 
-/** Default polar angle when entering 3D mode */
-export const DEFAULT_3D_POLAR = Math.PI / 4 // 45°
-
 /** Near-zero polar angle for top-down 2D view (avoids spherical singularity) */
 export const TOP_DOWN_POLAR = 0.001
 

--- a/src/components/threeJS/constants.ts
+++ b/src/components/threeJS/constants.ts
@@ -32,3 +32,11 @@ export const SNAP_RADIUS_METERS = 0.5
  * Storage is unaffected - only rendering positions are lifted by this amount.
  */
 export const DRAWING_LIFT = 0.05
+
+/**
+ * Vertical offset for navigation overlay markers (start / destination rings).
+ * Larger than `DRAWING_LIFT` so the markers visibly hover above the room
+ * polygons in 3D oblique views; depth-testing is also disabled on these so
+ * the lift is mainly a 3D affordance.
+ */
+export const MARKER_LIFT = DRAWING_LIFT * 4

--- a/src/components/threeJS/draw-primitives.tsx
+++ b/src/components/threeJS/draw-primitives.tsx
@@ -52,6 +52,33 @@ export const VertexMarker = ({ position, color = "#ffffff", radius = 0.06 }: Ver
   )
 }
 
+interface RingMarkerProps {
+  position: THREE.Vector3 | [number, number, number]
+  color: string
+  innerRadius?: number
+  outerRadius?: number
+}
+
+/**
+ * Flat ring laid on the floor plane (rotated to face up). Used for
+ * navigation overlay cues (start / destination) where a hollow ring reads
+ * better than a solid sphere on top of polygons.
+ *
+ * Rendered with `depthTest={false}` so the marker stays visible even when
+ * stacked under floor textures or polygon fills.
+ */
+export const RingMarker = ({
+  position,
+  color,
+  innerRadius = 0.5,
+  outerRadius = 0.85,
+}: RingMarkerProps) => (
+  <mesh position={position} rotation={[-Math.PI / 2, 0, 0]}>
+    <ringGeometry args={[innerRadius, outerRadius, 48]} />
+    <meshBasicMaterial color={color} transparent opacity={0.95} depthTest={false} />
+  </mesh>
+)
+
 interface EdgePreviewProps {
   points: readonly (THREE.Vector3 | [number, number, number])[]
   color?: string

--- a/src/components/threeJS/drawing-layer.tsx
+++ b/src/components/threeJS/drawing-layer.tsx
@@ -4,12 +4,13 @@ import * as THREE from "three"
 
 import { MIN_POLYGON_VERTICES } from "#/components/hooks/use-room-drawing-state"
 import { useMap } from "#/lib/map-context"
+import { floorToY, lift, snapPointToGrid } from "#/lib/three-utils"
 import { getAllRoomsData } from "#/server/room.functions"
 
 import { useCanvasPointer } from "../hooks/use-canvas-pointer"
 import { useSnapToExisting } from "../hooks/use-snap-to-existing"
 
-import { DRAWING_LIFT, FLOOR_HEIGHT, SNAP_RADIUS_METERS } from "./constants"
+import { SNAP_RADIUS_METERS } from "./constants"
 import { EdgePreview, VertexMarker } from "./draw-primitives"
 import { RaycastPlane } from "./raycast-plane"
 
@@ -35,9 +36,6 @@ const POLYLINE_WIDTH = 4
 const PREVIEW_WIDTH = 3
 const EXTERNAL_CORNER_RENDER_RADIUS_MULTIPLIER = 3
 
-/** Lift a world-space point above the floor plane to avoid z-fighting. */
-const lift = (v: THREE.Vector3): [number, number, number] => [v.x, v.y + DRAWING_LIFT, v.z]
-
 /**
  * Position equality on the floor's local 2D plane (x, z). Used instead of
  * reference identity because vertices stored in the drawing state are
@@ -58,14 +56,6 @@ const samePosition = (a: THREE.Vector3, b: THREE.Vector3): boolean => a.x === b.
  * and added to the snap target list, so adjacent rooms can share walls by
  * placing new vertices exactly at the existing corners.
  */
-/** Snap a world point to the nearest intersection of a grid with given spacing. */
-const snapPointToGrid = (point: THREE.Vector3, spacing: number, floorY: number): THREE.Vector3 =>
-  new THREE.Vector3(
-    Math.round(point.x / spacing) * spacing,
-    floorY,
-    Math.round(point.z / spacing) * spacing,
-  )
-
 const buildAxisAlignedRectangle = (
   anchor: THREE.Vector3,
   opposite: THREE.Vector3,
@@ -86,7 +76,7 @@ export const DrawingLayer = ({ floor }: DrawingLayerProps) => {
 
   const [cursor, setCursor] = useState<THREE.Vector3 | null>(null)
 
-  const floorY = floor.floor * FLOOR_HEIGHT
+  const floorY = floorToY(floor.floor)
 
   /**
    * Apply grid snap if enabled AND the grid has a known spacing. Returns the

--- a/src/components/threeJS/floor-plane.tsx
+++ b/src/components/threeJS/floor-plane.tsx
@@ -5,8 +5,7 @@ import { useRef } from "react"
 import * as THREE from "three"
 
 import { worldFromPixel } from "#/lib/coordinates"
-
-import { FLOOR_HEIGHT } from "./constants"
+import { floorToY } from "#/lib/three-utils"
 
 import type { FloorPlan } from "#/types/floor-plan"
 
@@ -47,11 +46,7 @@ export const FloorPlane = ({ floor, active, neighbourOpacityRef }: FloorPlanePro
   })
 
   return (
-    <mesh
-      ref={meshRef}
-      rotation={[-Math.PI / 2, 0, 0]}
-      position={[0, floor.floor * FLOOR_HEIGHT, 0]}
-    >
+    <mesh ref={meshRef} rotation={[-Math.PI / 2, 0, 0]} position={[0, floorToY(floor.floor), 0]}>
       <planeGeometry args={[width, height]} />
       <meshBasicMaterial
         ref={materialRef}

--- a/src/components/threeJS/graph-layer.tsx
+++ b/src/components/threeJS/graph-layer.tsx
@@ -6,13 +6,14 @@ import * as THREE from "three"
 
 import { useMap } from "#/lib/map-context"
 import { pointStrictlyInsidePolygon } from "#/lib/polygon-validation"
+import { floorToY, lift, mapPointToThree, snapPointToGrid } from "#/lib/three-utils"
 import { getAllEdgesData, getAllNodesData } from "#/server/graph.functions"
 import { getAllRoomsData } from "#/server/room.functions"
 
 import { useCanvasPointer } from "../hooks/use-canvas-pointer"
 import { useSnapToExisting } from "../hooks/use-snap-to-existing"
 
-import { DRAWING_LIFT, FLOOR_HEIGHT, SNAP_RADIUS_METERS } from "./constants"
+import { SNAP_RADIUS_METERS } from "./constants"
 import { EdgePreview, VertexMarker } from "./draw-primitives"
 import { RaycastPlane } from "./raycast-plane"
 
@@ -35,28 +36,11 @@ const SNAP_HALO_RADIUS = 0.22
 const BASE_CAMERA_ZOOM = 60
 const DRAG_THRESHOLD_PX = 5
 
-const lift = (v: THREE.Vector3): [number, number, number] => [v.x, v.y + DRAWING_LIFT, v.z]
-
-const snapPointToGrid = (point: THREE.Vector3, spacing: number, floorY: number): THREE.Vector3 =>
-  new THREE.Vector3(
-    Math.round(point.x / spacing) * spacing,
-    floorY,
-    Math.round(point.z / spacing) * spacing,
-  )
-
 type NodeRecord = Awaited<ReturnType<typeof getAllNodesData>>[number]
 
 /** Clickable, zoom-stable sphere for an existing node. Stops propagation so
  *  the RaycastPlane underneath doesn't also fire and open the create panel. */
-const ClickableNode = ({
-  node,
-  floorY,
-  highlighted,
-}: {
-  node: NodeRecord
-  floorY: number
-  highlighted: boolean
-}) => {
+const ClickableNode = ({ node, highlighted }: { node: NodeRecord; highlighted: boolean }) => {
   const { setEditingNodeId, setPendingNode } = useMap()
   const meshRef = useRef<THREE.Mesh>(null)
   const downRef = useRef<{ x: number; y: number } | null>(null)
@@ -71,7 +55,7 @@ const ClickableNode = ({
   return (
     <mesh
       ref={meshRef}
-      position={[node.x, floorY + DRAWING_LIFT, -node.y]}
+      position={mapPointToThree(node)}
       onPointerDown={(e) => {
         e.stopPropagation()
         downRef.current = { x: e.clientX, y: e.clientY }
@@ -113,7 +97,7 @@ export const GraphLayer = ({ floor }: GraphLayerProps) => {
   } = useMap()
   const [cursor, setCursor] = useState<THREE.Vector3 | null>(null)
 
-  const floorY = floor.floor * FLOOR_HEIGHT
+  const floorY = floorToY(floor.floor)
 
   const applyGridSnap = useCallback(
     (point: THREE.Vector3): THREE.Vector3 => {
@@ -214,10 +198,7 @@ export const GraphLayer = ({ floor }: GraphLayerProps) => {
         return (
           <EdgePreview
             key={edge.id}
-            points={[
-              [a.x, floorY + DRAWING_LIFT, -a.y],
-              [b.x, floorY + DRAWING_LIFT, -b.y],
-            ]}
+            points={[mapPointToThree(a), mapPointToThree(b)]}
             color={edge.isActivated ? "#3b82f6" : "#ef4444"}
             lineWidth={1.5}
           />
@@ -225,17 +206,12 @@ export const GraphLayer = ({ floor }: GraphLayerProps) => {
       })}
 
       {floorNodes.map((node) => (
-        <ClickableNode
-          key={node.id}
-          node={node}
-          floorY={floorY}
-          highlighted={node.id === editingNodeId}
-        />
+        <ClickableNode key={node.id} node={node} highlighted={node.id === editingNodeId} />
       ))}
 
       {pendingNode?.floor === floor.floor && (
         <VertexMarker
-          position={[pendingNode.x, floorY + DRAWING_LIFT, -pendingNode.y]}
+          position={mapPointToThree(pendingNode)}
           color={NODE_HIGHLIGHT_COLOR}
           radius={NODE_RADIUS}
         />

--- a/src/components/threeJS/map-scene.tsx
+++ b/src/components/threeJS/map-scene.tsx
@@ -13,6 +13,7 @@ import { CursorCoordinates } from "./cursor-coordinates"
 import { DrawingLayer } from "./drawing-layer"
 import { FloorPlane } from "./floor-plane"
 import { GraphLayer } from "./graph-layer"
+import { NavigationMarkers } from "./navigation-markers"
 import { RoomPolygonsLayer } from "./room-polygons-layer"
 
 /** Tools whose workflow benefits from seeing the grid. */
@@ -83,6 +84,7 @@ export const MapScene = () => {
         <AdaptiveGrid visible={showGrid} />
         <CursorCoordinates />
         <RoomPolygonsLayer neighbourOpacityRef={neighbourOpacityRef} />
+        <NavigationMarkers />
         {activeTool === "draw-room" && activeFloorPlan && <DrawingLayer floor={activeFloorPlan} />}
         {activeTool === "draw-node" && activeFloorPlan && <GraphLayer floor={activeFloorPlan} />}
         {activeTool === "connect-edge" && activeFloorPlan && (

--- a/src/components/threeJS/navigation-markers.tsx
+++ b/src/components/threeJS/navigation-markers.tsx
@@ -1,5 +1,7 @@
+import { Html } from "@react-three/drei"
 import { useMemo } from "react"
 
+import { useMap } from "#/lib/map-context"
 import { useNavigation } from "#/lib/navigation-context"
 import { floorToY, mapPointToThree, polygonCentroid } from "#/lib/three-utils"
 
@@ -11,52 +13,90 @@ import type { Room } from "#/types/room"
 
 const START_COLOR = "#3b82f6"
 const DESTINATION_COLOR = "#f97316"
+const LABEL_LIFT = MARKER_LIFT + 0.8
+
+interface MarkerPlacement {
+  position: [number, number, number]
+  floor: number
+}
 
 /**
- * Convert any value carried by NavigationRequest into a three.js position
- * tuple ready to drop into a marker mesh.
+ * Convert a navigation value into a three.js position + the floor it lives
+ * on (so the caller can decide whether to render it under the current view).
  *
  * - **Room**: centroid of the polygon vertices (already in `(x, z)` floor
  *   axes), lifted to the room's floor.
  * - **Node** / **map-picked point**: standard map → three conversion
  *   (`-y` → three.z), lifted to the floor.
  */
-const navigationValueToThreePosition = (
-  value: NavigationStart | Room,
-): [number, number, number] => {
+const navigationValueToPlacement = (value: NavigationStart | Room): MarkerPlacement => {
   if ("roomNumber" in value) {
     const c = polygonCentroid(value.vertices)
-    return [c.x, floorToY(value.floor, MARKER_LIFT), c.z]
+    return { position: [c.x, floorToY(value.floor, MARKER_LIFT), c.z], floor: value.floor }
   }
-  return mapPointToThree(value, MARKER_LIFT)
+  return { position: mapPointToThree(value, MARKER_LIFT), floor: value.floor }
+}
+
+interface MarkerProps {
+  placement: MarkerPlacement
+  color: string
+  label: string
+}
+
+const Marker = ({ placement, color, label }: MarkerProps) => {
+  const labelPosition: [number, number, number] = [
+    placement.position[0],
+    placement.position[1] + LABEL_LIFT,
+    placement.position[2],
+  ]
+  return (
+    <>
+      <RingMarker position={placement.position} color={color} />
+      <Html position={labelPosition} center zIndexRange={[0, 0]} pointerEvents="none">
+        <div
+          className="rounded-full px-2.5 py-1 text-xs font-semibold whitespace-nowrap text-white shadow-lg"
+          style={{ backgroundColor: color }}
+        >
+          {label}
+        </div>
+      </Html>
+    </>
+  )
 }
 
 /**
  * Always-on visual cues for the active navigation request.
  *
- * - Start: blue ring at the picked coordinate / chosen room centroid.
- * - Destination: orange ring at the destination room centroid.
+ * - Start: blue ring + "Start" label at the picked coordinate / chosen
+ *   room centroid.
+ * - Destination: orange ring + "Destination" label at the destination
+ *   room centroid.
  *
- * Rendered above the floor texture and with depth testing disabled
- * (see `RingMarker`) so the markers stay visible on top of polygons.
+ * In 3D mode both markers render regardless of which floor the camera is
+ * focused on (the floor stacking makes them visible). In 2D top-down mode
+ * a marker is only rendered when its floor matches `currentFloor`, so the
+ * ring doesn't project onto an unrelated floor's plan.
  */
 export const NavigationMarkers = () => {
   const { start, destination } = useNavigation()
+  const { renderMode, currentFloor } = useMap()
 
-  const startPosition = useMemo(
-    () => (start ? navigationValueToThreePosition(start) : null),
-    [start],
-  )
-  const destinationPosition = useMemo(
-    () => (destination ? navigationValueToThreePosition(destination) : null),
+  const startPlacement = useMemo(() => (start ? navigationValueToPlacement(start) : null), [start])
+  const destinationPlacement = useMemo(
+    () => (destination ? navigationValueToPlacement(destination) : null),
     [destination],
   )
 
+  const isVisibleOnCurrentView = (placement: MarkerPlacement) =>
+    renderMode === "3d" || placement.floor === currentFloor
+
   return (
     <>
-      {startPosition && <RingMarker position={startPosition} color={START_COLOR} />}
-      {destinationPosition && (
-        <RingMarker position={destinationPosition} color={DESTINATION_COLOR} />
+      {startPlacement && isVisibleOnCurrentView(startPlacement) && (
+        <Marker placement={startPlacement} color={START_COLOR} label="Start" />
+      )}
+      {destinationPlacement && isVisibleOnCurrentView(destinationPlacement) && (
+        <Marker placement={destinationPlacement} color={DESTINATION_COLOR} label="Destination" />
       )}
     </>
   )

--- a/src/components/threeJS/navigation-markers.tsx
+++ b/src/components/threeJS/navigation-markers.tsx
@@ -1,0 +1,62 @@
+import { useMemo } from "react"
+
+import { useNavigation } from "#/lib/navigation-context"
+import { floorToY, mapPointToThree, polygonCentroid } from "#/lib/three-utils"
+
+import { MARKER_LIFT } from "./constants"
+import { RingMarker } from "./draw-primitives"
+
+import type { NavigationRequest } from "#/lib/navigation-context"
+
+const START_COLOR = "#3b82f6"
+const DESTINATION_COLOR = "#f97316"
+
+/**
+ * Convert any value carried by NavigationRequest into a three.js position
+ * tuple ready to drop into a marker mesh.
+ *
+ * - **Room**: centroid of the polygon vertices (already in `(x, z)` floor
+ *   axes), lifted to the room's floor.
+ * - **Node** / **map-picked point**: standard map → three conversion
+ *   (`-y` → three.z), lifted to the floor.
+ */
+const navigationValueToThreePosition = (
+  value: NavigationRequest["start"],
+): [number, number, number] => {
+  if ("roomNumber" in value) {
+    const c = polygonCentroid(value.vertices)
+    return [c.x, floorToY(value.floor, MARKER_LIFT), c.z]
+  }
+  return mapPointToThree(value, MARKER_LIFT)
+}
+
+/**
+ * Always-on visual cues for the active navigation request.
+ *
+ * - Start: blue ring at the picked coordinate / chosen room centroid.
+ * - Destination: orange ring at the destination room centroid.
+ *
+ * Rendered above the floor texture and with depth testing disabled
+ * (see `RingMarker`) so the markers stay visible on top of polygons.
+ */
+export const NavigationMarkers = () => {
+  const { start, destination } = useNavigation()
+
+  const startPosition = useMemo(
+    () => (start ? navigationValueToThreePosition(start) : null),
+    [start],
+  )
+  const destinationPosition = useMemo(
+    () => (destination ? navigationValueToThreePosition(destination) : null),
+    [destination],
+  )
+
+  return (
+    <>
+      {startPosition && <RingMarker position={startPosition} color={START_COLOR} />}
+      {destinationPosition && (
+        <RingMarker position={destinationPosition} color={DESTINATION_COLOR} />
+      )}
+    </>
+  )
+}

--- a/src/components/threeJS/navigation-markers.tsx
+++ b/src/components/threeJS/navigation-markers.tsx
@@ -6,7 +6,8 @@ import { floorToY, mapPointToThree, polygonCentroid } from "#/lib/three-utils"
 import { MARKER_LIFT } from "./constants"
 import { RingMarker } from "./draw-primitives"
 
-import type { NavigationRequest } from "#/lib/navigation-context"
+import type { NavigationStart } from "#/types/navigation"
+import type { Room } from "#/types/room"
 
 const START_COLOR = "#3b82f6"
 const DESTINATION_COLOR = "#f97316"
@@ -21,7 +22,7 @@ const DESTINATION_COLOR = "#f97316"
  *   (`-y` → three.z), lifted to the floor.
  */
 const navigationValueToThreePosition = (
-  value: NavigationRequest["start"],
+  value: NavigationStart | Room,
 ): [number, number, number] => {
   if ("roomNumber" in value) {
     const c = polygonCentroid(value.vertices)

--- a/src/components/threeJS/navigation-markers.tsx
+++ b/src/components/threeJS/navigation-markers.tsx
@@ -1,4 +1,5 @@
 import { Html } from "@react-three/drei"
+import { CircleDot, MapPin } from "lucide-react"
 import { useMemo } from "react"
 
 import { useMap } from "#/lib/map-context"
@@ -6,14 +7,9 @@ import { useNavigation } from "#/lib/navigation-context"
 import { floorToY, mapPointToThree, polygonCentroid } from "#/lib/three-utils"
 
 import { MARKER_LIFT } from "./constants"
-import { RingMarker } from "./draw-primitives"
 
 import type { NavigationStart } from "#/types/navigation"
 import type { Room } from "#/types/room"
-
-const START_COLOR = "#3b82f6"
-const DESTINATION_COLOR = "#f97316"
-const LABEL_LIFT = MARKER_LIFT + 0.8
 
 interface MarkerPlacement {
   position: [number, number, number]
@@ -37,45 +33,20 @@ const navigationValueToPlacement = (value: NavigationStart | Room): MarkerPlacem
   return { position: mapPointToThree(value, MARKER_LIFT), floor: value.floor }
 }
 
-interface MarkerProps {
-  placement: MarkerPlacement
-  color: string
-  label: string
-}
-
-const Marker = ({ placement, color, label }: MarkerProps) => {
-  const labelPosition: [number, number, number] = [
-    placement.position[0],
-    placement.position[1] + LABEL_LIFT,
-    placement.position[2],
-  ]
-  return (
-    <>
-      <RingMarker position={placement.position} color={color} />
-      <Html position={labelPosition} center zIndexRange={[0, 0]} pointerEvents="none">
-        <div
-          className="rounded-full px-2.5 py-1 text-xs font-semibold whitespace-nowrap text-white shadow-lg"
-          style={{ backgroundColor: color }}
-        >
-          {label}
-        </div>
-      </Html>
-    </>
-  )
-}
-
 /**
- * Always-on visual cues for the active navigation request.
+ * Always-on visual cues for the active navigation request. Both markers
+ * render as lucide icons via drei `<Html>` overlays so they share the same
+ * renderer (matching room icons) and react identically to camera zoom.
  *
- * - Start: blue ring + "Start" label at the picked coordinate / chosen
+ * - Start: blue `CircleDot` centered on the picked coordinate / chosen
  *   room centroid.
- * - Destination: orange ring + "Destination" label at the destination
+ * - Destination: red `MapPin` anchored with its tip on the destination
  *   room centroid.
  *
  * In 3D mode both markers render regardless of which floor the camera is
  * focused on (the floor stacking makes them visible). In 2D top-down mode
  * a marker is only rendered when its floor matches `currentFloor`, so the
- * ring doesn't project onto an unrelated floor's plan.
+ * marker doesn't project onto an unrelated floor's plan.
  */
 export const NavigationMarkers = () => {
   const { start, destination } = useNavigation()
@@ -93,10 +64,22 @@ export const NavigationMarkers = () => {
   return (
     <>
       {startPlacement && isVisibleOnCurrentView(startPlacement) && (
-        <Marker placement={startPlacement} color={START_COLOR} label="Start" />
+        <Html position={startPlacement.position} center zIndexRange={[0, 0]} pointerEvents="none">
+          <CircleDot className="size-9 text-blue-500 drop-shadow-lg" strokeWidth={2.5} />
+        </Html>
       )}
       {destinationPlacement && isVisibleOnCurrentView(destinationPlacement) && (
-        <Marker placement={destinationPlacement} color={DESTINATION_COLOR} label="Destination" />
+        <Html
+          position={destinationPlacement.position}
+          center
+          zIndexRange={[0, 0]}
+          pointerEvents="none"
+        >
+          <MapPin
+            className="size-9 -translate-y-1/2 text-red-500 drop-shadow-lg"
+            strokeWidth={2.5}
+          />
+        </Html>
       )}
     </>
   )

--- a/src/components/threeJS/raycast-plane.tsx
+++ b/src/components/threeJS/raycast-plane.tsx
@@ -2,9 +2,8 @@
 import { useTexture } from "@react-three/drei"
 import * as THREE from "three"
 
+import { floorToY } from "#/lib/three-utils"
 import type { ThreeEvent } from "@react-three/fiber"
-
-import { FLOOR_HEIGHT } from "./constants"
 
 import type { FloorPlan } from "#/types/floor-plan"
 
@@ -41,7 +40,7 @@ export const RaycastPlane = ({
   return (
     <mesh
       rotation={[-Math.PI / 2, 0, 0]}
-      position={[0, floor.floor * FLOOR_HEIGHT, 0]}
+      position={[0, floorToY(floor.floor), 0]}
       onPointerDown={onPointerDown}
       onPointerUp={onPointerUp}
       onPointerMove={onPointerMove}

--- a/src/components/threeJS/room-polygons-layer.tsx
+++ b/src/components/threeJS/room-polygons-layer.tsx
@@ -15,7 +15,7 @@ import { useCanvasPointer } from "../hooks/use-canvas-pointer"
 import { DRAWING_LIFT } from "./constants"
 import { EdgePreview } from "./draw-primitives"
 
-import type { PersistedRoom, RoomVertex } from "#/server/room.server"
+import type { Room, RoomVertex } from "#/types/room"
 
 const ROOM_FILL_OPACITY = 0.6
 const SELECTED_FILL_OPACITY = 0.8
@@ -58,7 +58,7 @@ const buildPolygonGeometry = (vertices: RoomVertex[]): THREE.BufferGeometry => {
 }
 
 interface RoomPolygonProps {
-  room: PersistedRoom
+  room: Room
   active: boolean
   selected: boolean
   editable: boolean

--- a/src/components/threeJS/room-polygons-layer.tsx
+++ b/src/components/threeJS/room-polygons-layer.tsx
@@ -6,6 +6,7 @@ import { useCallback, useMemo, useRef, useState } from "react"
 import * as THREE from "three"
 
 import { useMap } from "#/lib/map-context"
+import { useNavigation } from "#/lib/navigation-context"
 import { getRoomTypeMeta, getRoomTypeOutline } from "#/lib/room-types"
 import { floorToY, polygonCentroid } from "#/lib/three-utils"
 import { getAllRoomsData } from "#/server/room.functions"
@@ -211,6 +212,7 @@ export const RoomPolygonsLayer = ({ neighbourOpacityRef }: RoomPolygonsLayerProp
     setViewingRoomId,
     pickingStart,
   } = useMap()
+  const { activeField, pickRoomForActiveField } = useNavigation()
 
   const { data: rooms = [] } = useQuery({
     queryKey: ["rooms"],
@@ -226,15 +228,20 @@ export const RoomPolygonsLayer = ({ neighbourOpacityRef }: RoomPolygonsLayerProp
 
   const isEditing = activeTool === "edit-room"
   const isIdle = activeTool === "default"
+  const isPickingForNav = activeField !== null
   // Rooms are inert while the user is picking a coordinate on the map; clicks
   // would otherwise open the room info drawer on top of the pick overlay.
-  const roomsAreClickable = (isEditing || isIdle) && !pickingStart
+  const roomsAreClickable = (isEditing || isIdle || isPickingForNav) && !pickingStart
 
-  const handleSelect = (id: string) => {
-    if (isEditing) {
-      setEditingRoomId(id)
+  const handleSelect = (room: Room) => {
+    if (isPickingForNav) {
+      // Mirrors the edit-room flow: while the navigation panel has an active
+      // field, clicks populate it directly instead of opening the info drawer.
+      pickRoomForActiveField(room)
+    } else if (isEditing) {
+      setEditingRoomId(room.id)
     } else {
-      setViewingRoomId(id)
+      setViewingRoomId(room.id)
     }
   }
 
@@ -248,7 +255,7 @@ export const RoomPolygonsLayer = ({ neighbourOpacityRef }: RoomPolygonsLayerProp
           selected={room.id === editingRoomId || room.id === viewingRoomId}
           editable={roomsAreClickable && room.floor === currentFloor}
           onSelect={() => {
-            handleSelect(room.id)
+            handleSelect(room)
           }}
           neighbourOpacityRef={neighbourOpacityRef}
         />

--- a/src/components/threeJS/room-polygons-layer.tsx
+++ b/src/components/threeJS/room-polygons-layer.tsx
@@ -7,11 +7,12 @@ import * as THREE from "three"
 
 import { useMap } from "#/lib/map-context"
 import { getRoomTypeMeta, getRoomTypeOutline } from "#/lib/room-types"
+import { floorToY, polygonCentroid } from "#/lib/three-utils"
 import { getAllRoomsData } from "#/server/room.functions"
 
 import { useCanvasPointer } from "../hooks/use-canvas-pointer"
 
-import { DRAWING_LIFT, FLOOR_HEIGHT } from "./constants"
+import { DRAWING_LIFT } from "./constants"
 import { EdgePreview } from "./draw-primitives"
 
 import type { PersistedRoom, RoomVertex } from "#/server/room.server"
@@ -56,17 +57,6 @@ const buildPolygonGeometry = (vertices: RoomVertex[]): THREE.BufferGeometry => {
   return geometry
 }
 
-const computeCentroid = (vertices: RoomVertex[]): { x: number; z: number } => {
-  let sumX = 0
-  let sumZ = 0
-  for (const v of vertices) {
-    sumX += v.x
-    sumZ += v.z
-  }
-  const n = vertices.length
-  return { x: sumX / n, z: sumZ / n }
-}
-
 interface RoomPolygonProps {
   room: PersistedRoom
   active: boolean
@@ -105,9 +95,9 @@ const RoomPolygon = ({
   const fillColor = useMemo(() => getRoomTypeMeta(room.type).color, [room.type])
   const TypeIcon = useMemo(() => getRoomTypeMeta(room.type).icon, [room.type])
   const outlineColor = useMemo(() => getRoomTypeOutline(room.type), [room.type])
-  const centroid = useMemo(() => computeCentroid(room.vertices), [room.vertices])
+  const centroid = useMemo(() => polygonCentroid(room.vertices), [room.vertices])
 
-  const yFill = room.floor * FLOOR_HEIGHT + DRAWING_LIFT
+  const yFill = floorToY(room.floor, DRAWING_LIFT)
   const yOutline = yFill + OUTLINE_LIFT
   const iconPosition = useMemo(
     () => new THREE.Vector3(centroid.x, yOutline, centroid.z),
@@ -219,6 +209,7 @@ export const RoomPolygonsLayer = ({ neighbourOpacityRef }: RoomPolygonsLayerProp
     setEditingRoomId,
     viewingRoomId,
     setViewingRoomId,
+    pickingStart,
   } = useMap()
 
   const { data: rooms = [] } = useQuery({
@@ -235,7 +226,9 @@ export const RoomPolygonsLayer = ({ neighbourOpacityRef }: RoomPolygonsLayerProp
 
   const isEditing = activeTool === "edit-room"
   const isIdle = activeTool === "default"
-  const roomsAreClickable = isEditing || isIdle
+  // Rooms are inert while the user is picking a coordinate on the map; clicks
+  // would otherwise open the room info drawer on top of the pick overlay.
+  const roomsAreClickable = (isEditing || isIdle) && !pickingStart
 
   const handleSelect = (id: string) => {
     if (isEditing) {

--- a/src/components/ui/button-group.tsx
+++ b/src/components/ui/button-group.tsx
@@ -52,10 +52,7 @@ export const ButtonGroupSeparator = ({
   />
 )
 
-export const ButtonGroupText = ({
-  className,
-  ...props
-}: ComponentPropsWithoutRef<"span">) => (
+export const ButtonGroupText = ({ className, ...props }: ComponentPropsWithoutRef<"span">) => (
   <span
     className={cn(
       "inline-flex items-center px-3 text-sm text-muted-foreground bg-card border border-border",

--- a/src/components/ui/button-group.tsx
+++ b/src/components/ui/button-group.tsx
@@ -1,0 +1,66 @@
+import { cn } from "#/lib/utils"
+
+import type { ComponentPropsWithoutRef } from "react"
+
+interface ButtonGroupProps extends ComponentPropsWithoutRef<"div"> {
+  orientation?: "horizontal" | "vertical"
+}
+
+/**
+ * Visual container for a row (or column) of related buttons. Adjacent
+ * children are squared off where they meet so they read as a single
+ * connected control. Each button still owns its own state — toggle
+ * semantics are the caller's responsibility (e.g. via `aria-pressed`).
+ */
+export const ButtonGroup = ({
+  className,
+  orientation = "horizontal",
+  children,
+  ...props
+}: ButtonGroupProps) => (
+  <div
+    role="group"
+    data-orientation={orientation}
+    className={cn(
+      "inline-flex isolate",
+      orientation === "horizontal"
+        ? "flex-row [&>*:not(:first-child)]:rounded-l-none [&>*:not(:first-child)]:-ml-px [&>*:not(:last-child)]:rounded-r-none"
+        : "flex-col [&>*:not(:first-child)]:rounded-t-none [&>*:not(:first-child)]:-mt-px [&>*:not(:last-child)]:rounded-b-none",
+      "[&>*:focus-visible]:z-10",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+  </div>
+)
+
+export const ButtonGroupSeparator = ({
+  className,
+  orientation = "vertical",
+  ...props
+}: ComponentPropsWithoutRef<"div"> & { orientation?: "horizontal" | "vertical" }) => (
+  <div
+    role="separator"
+    aria-orientation={orientation}
+    className={cn(
+      "bg-border self-stretch",
+      orientation === "vertical" ? "w-px" : "h-px",
+      className,
+    )}
+    {...props}
+  />
+)
+
+export const ButtonGroupText = ({
+  className,
+  ...props
+}: ComponentPropsWithoutRef<"span">) => (
+  <span
+    className={cn(
+      "inline-flex items-center px-3 text-sm text-muted-foreground bg-card border border-border",
+      className,
+    )}
+    {...props}
+  />
+)

--- a/src/components/ui/search-bar.tsx
+++ b/src/components/ui/search-bar.tsx
@@ -1,9 +1,8 @@
-"use client"
-
 import * as React from "react"
 import { Search, X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { SearchResultList, type SearchResultItem } from "./search-result-list"
+import { Input } from "./input"
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -57,6 +56,37 @@ export type SearchBarProps =
   | SearchBarIntegratedProps
   | SearchBarFieldProps
 
+// ─── Shared input ─────────────────────────────────────────────────────────────
+
+interface SearchInputProps extends Omit<React.ComponentProps<"input">, "type"> {
+  /** When set, marks the input as a combobox controlling a results dropdown. */
+  combobox?: { expanded: boolean; controlsId?: string }
+}
+
+/**
+ * Bare input shared by all three SearchBar modes. Strips the wrapping
+ * shadcn `Input` borders/shadow/padding so the surrounding pill provides
+ * the visual chrome, and hides the WebKit "x" so we can render our own.
+ */
+const SearchInput = ({ combobox, className, ...props }: SearchInputProps) => (
+  <Input
+    type="search"
+    role={combobox ? "combobox" : undefined}
+    aria-expanded={combobox?.expanded}
+    aria-autocomplete={combobox ? "list" : undefined}
+    aria-controls={combobox?.controlsId}
+    className={cn(
+      "flex-1 min-w-0 bg-transparent text-foreground",
+      "placeholder:text-muted-foreground",
+      "text-base leading-6",
+      "focus:outline-none",
+      "[&::-webkit-search-cancel-button]:hidden",
+      className,
+    )}
+    {...props}
+  />
+)
+
 // ─── SearchBar ────────────────────────────────────────────────────────────────
 
 export function SearchBar(props: SearchBarProps) {
@@ -73,7 +103,7 @@ export function SearchBar(props: SearchBarProps) {
   const [isFocused, setIsFocused] = React.useState(false)
   const wrapperRef = React.useRef<HTMLDivElement>(null)
 
-  const query = controlledValue !== undefined ? controlledValue : internalQuery
+  const query = controlledValue ?? internalQuery
 
   // Sync if controlled
   React.useEffect(() => {
@@ -124,24 +154,16 @@ export function SearchBar(props: SearchBarProps) {
         {leadingIcon ?? (
           <Search className="w-5 h-5 text-muted-foreground shrink-0" aria-hidden="true" />
         )}
-        <input
-          type="search"
+        <SearchInput
           value={query}
+          placeholder={placeholder}
+          aria-label={inputAriaLabel ?? placeholder}
           onChange={handleChange}
+          onKeyDown={handleKeyDown}
           onFocus={() => {
             setIsFocused(true)
             onFocus?.()
           }}
-          onKeyDown={handleKeyDown}
-          placeholder={placeholder}
-          aria-label={inputAriaLabel ?? placeholder}
-          className={cn(
-            "flex-1 min-w-0 bg-transparent text-card-foreground",
-            "placeholder:text-muted-foreground",
-            "text-base leading-6",
-            "focus:outline-none",
-            "[&::-webkit-search-cancel-button]:hidden",
-          )}
         />
         {onClear && query.length > 0 && (
           <button
@@ -177,28 +199,20 @@ export function SearchBar(props: SearchBarProps) {
           {/* Input row */}
           <div className="flex items-center gap-3 px-4 py-3">
             <Search className="w-5 h-5 text-muted-foreground shrink-0" aria-hidden="true" />
-            <input
-              type="search"
+            <SearchInput
               value={query}
+              placeholder={placeholder}
+              aria-label={inputAriaLabel ?? placeholder}
               onChange={handleChange}
+              onKeyDown={handleKeyDown}
               onFocus={() => {
                 setIsFocused(true)
                 props.onFocus?.()
               }}
-              onKeyDown={handleKeyDown}
-              placeholder={placeholder}
-              aria-label={inputAriaLabel ?? placeholder}
-              aria-expanded={showDropdown}
-              aria-autocomplete="list"
-              aria-controls={showDropdown ? "search-results-dropdown" : undefined}
-              role="combobox"
-              className={cn(
-                "flex-1 min-w-0 bg-transparent text-foreground",
-                "placeholder:text-muted-foreground",
-                "text-base leading-6",
-                "focus:outline-none",
-                "[&::-webkit-search-cancel-button]:hidden",
-              )}
+              combobox={{
+                expanded: showDropdown,
+                controlsId: showDropdown ? "search-results-dropdown" : undefined,
+              }}
             />
           </div>
         </div>
@@ -235,22 +249,14 @@ export function SearchBar(props: SearchBarProps) {
       )}
     >
       <Search className="w-5 h-5 text-muted-foreground shrink-0" aria-hidden="true" />
-      <input
-        type="search"
+      <SearchInput
         value={query}
-        onChange={handleChange}
-        onFocus={() => setIsFocused(true)}
-        onBlur={() => setIsFocused(false)}
-        onKeyDown={handleKeyDown}
         placeholder={placeholder}
         aria-label={inputAriaLabel ?? placeholder}
-        className={cn(
-          "flex-1 min-w-0 bg-transparent text-foreground",
-          "placeholder:text-muted-foreground",
-          "text-base leading-6",
-          "focus:outline-none",
-          "[&::-webkit-search-cancel-button]:hidden",
-        )}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
       />
     </div>
   )

--- a/src/components/ui/search-bar.tsx
+++ b/src/components/ui/search-bar.tsx
@@ -2,7 +2,6 @@ import * as React from "react"
 import { Search, X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { SearchResultList, type SearchResultItem } from "./search-result-list"
-import { Input } from "./input"
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -69,7 +68,7 @@ interface SearchInputProps extends Omit<React.ComponentProps<"input">, "type"> {
  * the visual chrome, and hides the WebKit "x" so we can render our own.
  */
 const SearchInput = ({ combobox, className, ...props }: SearchInputProps) => (
-  <Input
+  <input
     type="search"
     role={combobox ? "combobox" : undefined}
     aria-expanded={combobox?.expanded}

--- a/src/components/ui/search-bar.tsx
+++ b/src/components/ui/search-bar.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { Search } from "lucide-react"
+import { Search, X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { SearchResultList, type SearchResultItem } from "./search-result-list"
 
@@ -13,6 +13,8 @@ interface SearchBarBaseProps {
   onQueryChange?: (query: string) => void
   /** Called when the search icon / Enter key is pressed (both modes) */
   onSearch?: (query: string) => void
+  /** Called when the input gains focus */
+  onFocus?: () => void
   className?: string
   /** Initial / controlled value */
   value?: string
@@ -35,7 +37,25 @@ interface SearchBarIntegratedProps extends SearchBarBaseProps {
   showResultsWhenEmpty?: boolean
 }
 
-export type SearchBarProps = SearchBarStandaloneProps | SearchBarIntegratedProps
+/**
+ * Field bar – integrated styling (rounded pill) with a customizable leading
+ * icon and no internal dropdown. Use when results are rendered elsewhere
+ * (e.g. in a panel body shared between multiple field instances).
+ */
+interface SearchBarFieldProps extends SearchBarBaseProps {
+  type: "field"
+  /** Leading icon. Defaults to a Search icon. */
+  leadingIcon?: React.ReactNode
+  /** Show a focus ring even when blurred (e.g. while this field owns the active search). */
+  active?: boolean
+  /** When set, renders a trailing X that calls this on click. */
+  onClear?: () => void
+}
+
+export type SearchBarProps =
+  | SearchBarStandaloneProps
+  | SearchBarIntegratedProps
+  | SearchBarFieldProps
 
 // ─── SearchBar ────────────────────────────────────────────────────────────────
 
@@ -88,6 +108,55 @@ export function SearchBar(props: SearchBarProps) {
     }
   }
 
+  // ── Field mode (rounded pill, custom leading icon, no dropdown) ─────────
+
+  if (props.type === "field") {
+    const { leadingIcon, active, onFocus, onClear } = props
+    return (
+      <div
+        className={cn(
+          "flex items-center gap-3 px-4 py-3",
+          "bg-card rounded-full shadow-md border border-border/60",
+          active && "ring-2 ring-primary/60",
+          className,
+        )}
+      >
+        {leadingIcon ?? (
+          <Search className="w-5 h-5 text-muted-foreground shrink-0" aria-hidden="true" />
+        )}
+        <input
+          type="search"
+          value={query}
+          onChange={handleChange}
+          onFocus={() => {
+            setIsFocused(true)
+            onFocus?.()
+          }}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          aria-label={inputAriaLabel ?? placeholder}
+          className={cn(
+            "flex-1 min-w-0 bg-transparent text-card-foreground",
+            "placeholder:text-muted-foreground",
+            "text-base leading-6",
+            "focus:outline-none",
+            "[&::-webkit-search-cancel-button]:hidden",
+          )}
+        />
+        {onClear && query.length > 0 && (
+          <button
+            type="button"
+            onClick={onClear}
+            aria-label="Clear"
+            className="shrink-0 rounded-full p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            <X className="w-4 h-4" aria-hidden="true" />
+          </button>
+        )}
+      </div>
+    )
+  }
+
   // ── Integrated mode (rounded, dropdown overlays content) ─────────────────
 
   if (props.type === "integrated") {
@@ -112,7 +181,10 @@ export function SearchBar(props: SearchBarProps) {
               type="search"
               value={query}
               onChange={handleChange}
-              onFocus={() => setIsFocused(true)}
+              onFocus={() => {
+                setIsFocused(true)
+                props.onFocus?.()
+              }}
               onKeyDown={handleKeyDown}
               placeholder={placeholder}
               aria-label={inputAriaLabel ?? placeholder}

--- a/src/components/ui/search-result-list.tsx
+++ b/src/components/ui/search-result-list.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { cn } from "@/lib/utils"
+import { Separator } from "./separator"
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -31,14 +32,14 @@ function ResultRow({
   item,
   onItemClick,
   showSeparator = false,
-}: {
+}: Readonly<{
   item: SearchResultItem
   onItemClick?: (item: SearchResultItem) => void
   showSeparator?: boolean
-}) {
+}>) {
   return (
     <li>
-      {showSeparator && <div className="h-px bg-border" aria-hidden="true" />}
+      {showSeparator && <Separator />}
       <button
         type="button"
         onClick={() => onItemClick?.(item)}
@@ -86,7 +87,7 @@ export function SearchResultList({
   onItemClick,
   className,
   bare = false,
-}: SearchResultListProps) {
+}: Readonly<SearchResultListProps>) {
   if (items.length === 0) return null
 
   const content = (

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -4,15 +4,16 @@ import { Separator as SeparatorPrimitive } from "@base-ui/react/separator"
 
 import { cn } from "#/lib/utils"
 
-function Separator({ className, orientation = "horizontal", ...props }: SeparatorPrimitive.Props) {
+type SeparatorProps = Readonly<SeparatorPrimitive.Props>
+
+function Separator({ className, orientation = "horizontal", ...props }: SeparatorProps) {
+  const orientationClasses = orientation === "horizontal" ? "h-px" : "w-px self-stretch"
+
   return (
     <SeparatorPrimitive
       data-slot="separator"
       orientation={orientation}
-      className={cn(
-        "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
-        className,
-      )}
+      className={cn("shrink-0 bg-border", orientationClasses, className)}
       {...props}
     />
   )

--- a/src/components/ui/toggle-group.tsx
+++ b/src/components/ui/toggle-group.tsx
@@ -1,0 +1,59 @@
+import { Toggle as TogglePrimitive } from "@base-ui/react/toggle"
+import { ToggleGroup as ToggleGroupPrimitive } from "@base-ui/react/toggle-group"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "#/lib/utils"
+
+import type { ComponentProps } from "react"
+
+const toggleVariants = cva(
+  "inline-flex items-center justify-center gap-1.5 cursor-pointer text-sm font-medium font-serif whitespace-nowrap select-none outline-none transition-colors focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 border border-border bg-card text-card-foreground hover:bg-muted data-[pressed]:bg-primary data-[pressed]:text-primary-foreground data-[pressed]:border-primary",
+  {
+    variants: {
+      size: {
+        default: "h-9 px-4",
+        sm: "h-8 px-3 text-xs",
+        lg: "h-10 px-5",
+      },
+    },
+    defaultVariants: {
+      size: "default",
+    },
+  },
+)
+
+/**
+ * Single- or multi-select toggle row. Wraps base-ui's `ToggleGroup` and
+ * styles its children to read as one connected control. The caller drives
+ * state via `value` / `onValueChange` (both arrays — `[selected]` for a
+ * single-select group).
+ */
+export const ToggleGroup = ({
+  className,
+  ...props
+}: ComponentProps<typeof ToggleGroupPrimitive>) => (
+  <ToggleGroupPrimitive
+    data-slot="toggle-group"
+    className={cn(
+      "inline-flex isolate rounded-md",
+      "[&>*:not(:first-child)]:rounded-l-none [&>*:not(:first-child)]:-ml-px",
+      "[&>*:not(:last-child)]:rounded-r-none",
+      "[&>*:first-child]:rounded-l-md [&>*:last-child]:rounded-r-md",
+      "[&>*[data-pressed]]:z-10 [&>*:focus-visible]:z-10",
+      className,
+    )}
+    {...props}
+  />
+)
+
+export const ToggleGroupItem = ({
+  className,
+  size,
+  ...props
+}: ComponentProps<typeof TogglePrimitive> & VariantProps<typeof toggleVariants>) => (
+  <TogglePrimitive
+    data-slot="toggle-group-item"
+    className={cn(toggleVariants({ size }), className)}
+    {...props}
+  />
+)

--- a/src/lib/auth-hooks.ts
+++ b/src/lib/auth-hooks.ts
@@ -1,9 +1,5 @@
 import { authClient } from "./auth-client"
 
-export function useSession() {
-  return authClient.useSession()
-}
-
 export function useIsLoggedIn() {
   const { data, isPending } = authClient.useSession()
   return {

--- a/src/lib/auth-server.ts
+++ b/src/lib/auth-server.ts
@@ -8,11 +8,3 @@ export const getServerSession = createServerFn({ method: "GET" }).handler(async 
   const session = await auth.api.getSession({ headers })
   return session
 })
-
-export async function requireSession() {
-  const session = await getServerSession()
-  if (!session) {
-    throw new Error("Unauthorized")
-  }
-  return session
-}

--- a/src/lib/coordinates.ts
+++ b/src/lib/coordinates.ts
@@ -1,10 +1,9 @@
-import * as THREE from "three"
-
 import { FLOOR_HEIGHT } from "#/components/threeJS/constants"
 
 import type { FloorPlan } from "#/types/floor-plan"
+import type * as THREE from "three"
 
-export interface WorldCoordinate {
+interface WorldCoordinate {
   x: number
   y: number
   z: number
@@ -35,11 +34,4 @@ export function mapFromWorld(position: THREE.Vector3): WorldCoordinate {
     y: -position.z,
     z: position.y / FLOOR_HEIGHT,
   }
-}
-
-/**
- * converts map coordinate → ThreeJS position
- */
-export function worldVectorFromMap(coord: WorldCoordinate): THREE.Vector3 {
-  return new THREE.Vector3(coord.x, coord.z * FLOOR_HEIGHT, -coord.y)
 }

--- a/src/lib/map-context.tsx
+++ b/src/lib/map-context.tsx
@@ -7,9 +7,10 @@ import type { OrbitControls as DreiOrbitControls } from "@react-three/drei"
 
 import type { RoomDrawingState } from "#/components/hooks/use-room-drawing-state"
 import type { FloorPlan } from "#/types/floor-plan"
+import type { PendingNode } from "#/types/node"
 import type { ComponentRef, ReactNode, RefObject } from "react"
 
-export type OrbitControlsHandle = ComponentRef<typeof DreiOrbitControls>
+type OrbitControlsHandle = ComponentRef<typeof DreiOrbitControls>
 
 type RenderMode = "2d" | "3d"
 type RoomDrawMode = "polygon" | "rectangle"
@@ -23,14 +24,6 @@ type RoomOverlayMode = "icon" | "none"
  * have to change again.
  */
 export type ActiveTool = "default" | "draw-room" | "edit-room" | "draw-node" | "connect-edge"
-
-export interface PendingNode {
-  x: number
-  y: number
-  z: number
-  floor: number
-  roomId?: string
-}
 
 interface MapContextValue {
   floors: FloorPlan[]

--- a/src/lib/map-context.tsx
+++ b/src/lib/map-context.tsx
@@ -108,6 +108,13 @@ interface MapContextValue {
    * Canvas (e.g. the compass) can read rotation and reset it.
    */
   controlsRef: RefObject<OrbitControlsHandle | null>
+  /**
+   * When true, an end-user is picking a coordinate on the map (entered from
+   * the navigation panel's "Select on map" result). The map-pick overlay
+   * renders a centered crosshair and a confirm/cancel toolbar.
+   */
+  pickingStart: boolean
+  setPickingStart: (picking: boolean) => void
 }
 
 const MapContext = createContext<MapContextValue | null>(null)
@@ -144,7 +151,9 @@ export const MapProvider = ({ children }: { children: ReactNode }) => {
   const [pendingNode, setPendingNode] = useState<PendingNode | null>(null)
   const [pendingEdgeFromNodeId, setPendingEdgeFromNodeId] = useState<string | null>(null)
   const [editingEdgeId, setEditingEdgeId] = useState<string | null>(null)
+  const [pickingStart, setPickingStart] = useState(false)
   const previousRenderModeRef = useRef<RenderMode | null>(null)
+  const previousRenderModeForPickRef = useRef<RenderMode | null>(null)
   const controlsRef = useRef<OrbitControlsHandle | null>(null)
   const gridSpacingRef = useRef<number | null>(null)
 
@@ -175,6 +184,25 @@ export const MapProvider = ({ children }: { children: ReactNode }) => {
       setPendingNode(null)
       setPendingEdgeFromNodeId(null)
       setEditingEdgeId(null)
+    },
+    [renderMode],
+  )
+
+  const handleSetPickingStart = useCallback(
+    (picking: boolean) => {
+      setPickingStart((current) => {
+        if (!current && picking) {
+          // Picking only resolves correctly in 2D top-down. Lock the render
+          // mode and remember the previous one to restore on exit.
+          previousRenderModeForPickRef.current = renderMode
+          setRenderMode("2d")
+        } else if (current && !picking) {
+          const previous = previousRenderModeForPickRef.current
+          previousRenderModeForPickRef.current = null
+          if (previous !== null) setRenderMode(previous)
+        }
+        return picking
+      })
     },
     [renderMode],
   )
@@ -233,6 +261,8 @@ export const MapProvider = ({ children }: { children: ReactNode }) => {
       setPendingEdgeFromNodeId,
       editingEdgeId,
       setEditingEdgeId,
+      pickingStart,
+      setPickingStart: handleSetPickingStart,
     }),
     [
       floors,
@@ -256,6 +286,8 @@ export const MapProvider = ({ children }: { children: ReactNode }) => {
       pendingNode,
       pendingEdgeFromNodeId,
       editingEdgeId,
+      pickingStart,
+      handleSetPickingStart,
     ],
   )
 

--- a/src/lib/navigation-context.tsx
+++ b/src/lib/navigation-context.tsx
@@ -1,8 +1,13 @@
-import { createContext, useContext, useMemo, useState } from "react"
+import { createContext, useCallback, useContext, useMemo, useState } from "react"
 
-import type { NavigationStart, RoutePreference } from "#/types/navigation"
+import { polygonCentroid } from "#/lib/three-utils"
+
 import type { Node } from "#/types/node"
+import type { NavigationStart, RoutePreference } from "#/types/navigation"
 import type { Room } from "#/types/room"
+
+/** Which navigation panel field the user is currently editing. */
+export type FieldKey = "start" | "destination"
 
 /**
  * The runtime navigation request. The wire shape sent to the A* server
@@ -20,22 +25,57 @@ interface NavigationContextValue {
   destination: NavigationRequest["destination"] | null
   preference: NavigationRequest["preference"]
   navigationPanelOpen: boolean
+  /**
+   * Which field the user is currently editing in the navigation panel.
+   * Lifted into the context so the map (room polygons, future click
+   * handlers) can populate the active field on a single click.
+   */
+  activeField: FieldKey | null
   navigationPath?: Node[]
   setStart: (start: NavigationRequest["start"] | null) => void
   setDestination: (destination: NavigationRequest["destination"] | null) => void
   setPreference: (preference: NavigationRequest["preference"]) => void
   setNavigationPanelOpen: (open: boolean) => void
+  setActiveField: (field: FieldKey | null) => void
+  /**
+   * Populate the currently-active field with a room the user clicked on the
+   * map. Start fields drop a pin at the room's centroid (start must be a
+   * point or a node — see `NavigationStart`); destination fields take the
+   * room directly. Clears `activeField` afterwards.
+   */
+  pickRoomForActiveField: (room: Room) => void
   setNavigationPath?: (path: Node[] | undefined) => void
 }
 
 const NavigationContext = createContext<NavigationContextValue | undefined>(undefined)
+
+/**
+ * Drop a pin at a room's centroid. `Room.vertices` use three.js floor-plane
+ * axes `(x, z)`; map coords use `(x, y)` where `y = -z`, so the conversion
+ * flips the forward axis.
+ */
+const roomToStartPoint = (room: Room) => {
+  const c = polygonCentroid(room.vertices)
+  return { x: c.x, y: -c.z, floor: room.floor }
+}
 
 export const NavigationProvider = ({ children }: { children: React.ReactNode }) => {
   const [start, setStart] = useState<NavigationRequest["start"] | null>(null)
   const [destination, setDestination] = useState<NavigationRequest["destination"] | null>(null)
   const [preference, setPreference] = useState<NavigationRequest["preference"]>("SIMPLE")
   const [navigationPanelOpen, setNavigationPanelOpen] = useState<boolean>(false)
+  const [activeField, setActiveField] = useState<FieldKey | null>(null)
   const [navigationPath, setNavigationPath] = useState<Node[] | undefined>(undefined)
+
+  const pickRoomForActiveField = useCallback(
+    (room: Room) => {
+      if (!activeField) return
+      if (activeField === "start") setStart(roomToStartPoint(room))
+      else setDestination(room)
+      setActiveField(null)
+    },
+    [activeField],
+  )
 
   const value = useMemo(
     () => ({
@@ -43,14 +83,25 @@ export const NavigationProvider = ({ children }: { children: React.ReactNode }) 
       destination,
       preference,
       navigationPanelOpen,
+      activeField,
       navigationPath,
       setStart,
       setDestination,
       setPreference,
       setNavigationPanelOpen,
+      setActiveField,
+      pickRoomForActiveField,
       setNavigationPath,
     }),
-    [start, destination, preference, navigationPanelOpen, navigationPath],
+    [
+      start,
+      destination,
+      preference,
+      navigationPanelOpen,
+      activeField,
+      navigationPath,
+      pickRoomForActiveField,
+    ],
   )
 
   return <NavigationContext.Provider value={value}>{children}</NavigationContext.Provider>

--- a/src/lib/navigation-context.tsx
+++ b/src/lib/navigation-context.tsx
@@ -9,9 +9,20 @@ export const routePreferences = {
   ACCESSIBLE: "accessible",
 } as const
 
+/**
+ * A coordinate the user picked on the map (no node, no room — just a point).
+ * Stored in *map* coordinates so it has the same shape as `Node` and can flow
+ * through the same conversion helpers.
+ */
+export interface MapPickedPoint {
+  x: number
+  y: number
+  floor: number
+}
+
 export interface NavigationRequest {
   preference: keyof typeof routePreferences
-  start: Node | { x: number; y: number; z: number; floor: number } | PersistedRoom
+  start: Node | MapPickedPoint | PersistedRoom
   destination: PersistedRoom
 }
 

--- a/src/lib/navigation-context.tsx
+++ b/src/lib/navigation-context.tsx
@@ -1,0 +1,64 @@
+import { createContext, useContext, useMemo, useState } from "react"
+
+import type { Room, Node } from "#/generated/prisma/client"
+
+export const routePreferences = {
+  SIMPLE: "simple",
+  FAST: "fast",
+  ACCESSIBLE: "accessible",
+} as const
+
+export interface NavigationRequest {
+  preference: keyof typeof routePreferences
+  start: Node | { x: number; y: number; z: number; floor: number }
+  destination: Room
+}
+
+interface NavigationContextValue {
+  start: NavigationRequest["start"] | null
+  destination: NavigationRequest["destination"] | null
+  preference: NavigationRequest["preference"]
+  navigationPanelOpen: boolean
+  navigationPath?: Node[]
+  setStart: (start: NavigationRequest["start"] | null) => void
+  setDestination: (destination: NavigationRequest["destination"] | null) => void
+  setPreference: (preference: NavigationRequest["preference"]) => void
+  setNavigationPanelOpen: (open: boolean) => void
+  setNavigationPath?: (path: Node[] | undefined) => void
+}
+
+const NavigationContext = createContext<NavigationContextValue | undefined>(undefined)
+
+export const NavigationProvider = ({ children }: { children: React.ReactNode }) => {
+  const [start, setStart] = useState<NavigationRequest["start"] | null>(null)
+  const [destination, setDestination] = useState<NavigationRequest["destination"] | null>(null)
+  const [preference, setPreference] = useState<NavigationRequest["preference"]>("SIMPLE")
+  const [navigationPanelOpen, setNavigationPanelOpen] = useState<boolean>(false)
+  const [navigationPath, setNavigationPath] = useState<Node[] | undefined>(undefined)
+
+  const value = useMemo(
+    () => ({
+      start,
+      destination,
+      preference,
+      navigationPanelOpen,
+      navigationPath,
+      setStart,
+      setDestination,
+      setPreference,
+      setNavigationPanelOpen,
+      setNavigationPath,
+    }),
+    [start, destination, preference, navigationPanelOpen, navigationPath],
+  )
+
+  return <NavigationContext.Provider value={value}>{children}</NavigationContext.Provider>
+}
+
+export const useNavigation = () => {
+  const context = useContext(NavigationContext)
+  if (!context) {
+    throw new Error("useNavigation must be used within a NavigationProvider")
+  }
+  return context
+}

--- a/src/lib/navigation-context.tsx
+++ b/src/lib/navigation-context.tsx
@@ -1,29 +1,18 @@
 import { createContext, useContext, useMemo, useState } from "react"
 
-import type { Node } from "#/generated/prisma/client"
-import type { PersistedRoom } from "#/server/room.server"
-
-export const routePreferences = {
-  SIMPLE: "simple",
-  FAST: "fast",
-  ACCESSIBLE: "accessible",
-} as const
+import type { NavigationStart, RoutePreference } from "#/types/navigation"
+import type { Node } from "#/types/node"
+import type { Room } from "#/types/room"
 
 /**
- * A coordinate the user picked on the map (no node, no room — just a point).
- * Stored in *map* coordinates so it has the same shape as `Node` and can flow
- * through the same conversion helpers.
+ * The runtime navigation request. The wire shape sent to the A* server
+ * (`AstarInput`) is structurally similar but requires a destination with
+ * its `nodes` relation included; we resolve that at call time.
  */
-export interface MapPickedPoint {
-  x: number
-  y: number
-  floor: number
-}
-
-export interface NavigationRequest {
-  preference: keyof typeof routePreferences
-  start: Node | MapPickedPoint | PersistedRoom
-  destination: PersistedRoom
+interface NavigationRequest {
+  preference: RoutePreference
+  start: NavigationStart
+  destination: Room
 }
 
 interface NavigationContextValue {

--- a/src/lib/navigation-context.tsx
+++ b/src/lib/navigation-context.tsx
@@ -2,8 +2,8 @@ import { createContext, useCallback, useContext, useMemo, useState } from "react
 
 import { polygonCentroid } from "#/lib/three-utils"
 
-import type { Node } from "#/types/node"
 import type { NavigationStart, RoutePreference } from "#/types/navigation"
+import type { Node } from "#/types/node"
 import type { Room } from "#/types/room"
 
 /** Which navigation panel field the user is currently editing. */

--- a/src/lib/navigation-context.tsx
+++ b/src/lib/navigation-context.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useMemo, useState } from "react"
 
-import type { Room, Node } from "#/generated/prisma/client"
+import type { Node } from "#/generated/prisma/client"
+import type { PersistedRoom } from "#/server/room.server"
 
 export const routePreferences = {
   SIMPLE: "simple",
@@ -10,8 +11,8 @@ export const routePreferences = {
 
 export interface NavigationRequest {
   preference: keyof typeof routePreferences
-  start: Node | { x: number; y: number; z: number; floor: number }
-  destination: Room
+  start: Node | { x: number; y: number; z: number; floor: number } | PersistedRoom
+  destination: PersistedRoom
 }
 
 interface NavigationContextValue {

--- a/src/lib/polygon-validation.ts
+++ b/src/lib/polygon-validation.ts
@@ -12,7 +12,7 @@
  */
 
 /** A 2D point in the floor frame. `THREE.Vector3` matches this structurally. */
-export interface PlanePoint {
+interface PlanePoint {
   x: number
   z: number
 }
@@ -106,7 +106,7 @@ export const pointStrictlyInsidePolygon = (
  * Returns the index of the first edge in the open polyline `vertices[0..n-1]`
  * that crosses another non-adjacent edge, or null if the polyline is simple.
  */
-export const openPolylineSelfIntersection = (vertices: readonly PlanePoint[]): number | null => {
+const openPolylineSelfIntersection = (vertices: readonly PlanePoint[]): number | null => {
   const n = vertices.length
   if (n < 4) return null
   for (let i = 0; i < n - 1; i++) {
@@ -123,7 +123,7 @@ export const openPolylineSelfIntersection = (vertices: readonly PlanePoint[]): n
  * Returns true if closing the polyline (drawing an edge from `vertices[n-1]`
  * back to `vertices[0]`) would cross any non-adjacent existing edge.
  */
-export const closingEdgeIntersectsPolyline = (vertices: readonly PlanePoint[]): boolean => {
+const closingEdgeIntersectsPolyline = (vertices: readonly PlanePoint[]): boolean => {
   const n = vertices.length
   if (n < 4) return false
   const closingStart = vertices[n - 1]

--- a/src/lib/room-format.tsx
+++ b/src/lib/room-format.tsx
@@ -1,13 +1,13 @@
 import { getRoomTypeMeta, getRoomTypeOutline } from "#/lib/room-types"
 
 import type { SearchResultItem } from "#/components/ui/search-result-list"
-import type { NavigationRequest } from "#/lib/navigation-context"
-import type { PersistedRoom } from "#/server/room.server"
+import type { NavigationStart } from "#/types/navigation"
+import type { Room } from "#/types/room"
 
 /** Visual separator between roomNumber and displayName in inline labels. */
 const ROOM_LABEL_SEPARATOR = "·"
 
-type RoomLabelInput = Pick<PersistedRoom, "roomNumber" | "displayName">
+type RoomLabelInput = Pick<Room, "roomNumber" | "displayName">
 
 /**
  * Single-line room label for inline display (field values, badges, summaries).
@@ -29,7 +29,7 @@ export const formatRoomLabel = (room: RoomLabelInput): string =>
  * Returns `""` for `null` so it can be dropped straight into a controlled
  * input value.
  */
-export const formatNavigationValue = (value: NavigationRequest["start"] | null): string => {
+export const formatNavigationValue = (value: NavigationStart | Room | null): string => {
   if (!value) return ""
   if ("roomNumber" in value) return formatRoomLabel(value)
   if ("id" in value) return `Node ${value.id.slice(0, 6)}`
@@ -49,7 +49,7 @@ export type RoomSearchResultItem = SearchResultItem & { dbId: string }
  * `dbId` is attached so click handlers can look the room up by primary key
  * instead of re-deriving it from `roomNumber`.
  */
-export const roomToSearchResultItem = (room: PersistedRoom): RoomSearchResultItem => {
+export const roomToSearchResultItem = (room: Room): RoomSearchResultItem => {
   const meta = getRoomTypeMeta(room.type)
   const outline = getRoomTypeOutline(room.type)
   const Icon = meta.icon

--- a/src/lib/room-format.tsx
+++ b/src/lib/room-format.tsx
@@ -1,0 +1,64 @@
+import { getRoomTypeMeta, getRoomTypeOutline } from "#/lib/room-types"
+
+import type { SearchResultItem } from "#/components/ui/search-result-list"
+import type { NavigationRequest } from "#/lib/navigation-context"
+import type { PersistedRoom } from "#/server/room.server"
+
+/** Visual separator between roomNumber and displayName in inline labels. */
+const ROOM_LABEL_SEPARATOR = "·"
+
+type RoomLabelInput = Pick<PersistedRoom, "roomNumber" | "displayName">
+
+/**
+ * Single-line room label for inline display (field values, badges, summaries).
+ * Renders as `"<roomNumber> · <displayName>"` when both exist, otherwise
+ * just `"<roomNumber>"`.
+ */
+export const formatRoomLabel = (room: RoomLabelInput): string =>
+  room.displayName
+    ? `${room.roomNumber} ${ROOM_LABEL_SEPARATOR} ${room.displayName}`
+    : room.roomNumber
+
+/**
+ * Single-line label for any value the navigation flow can carry as start or
+ * destination. Renders as:
+ * - Room → `formatRoomLabel(room)`
+ * - Node → `"Node <first 6 chars of id>"` (graph node picked on the map)
+ * - Bare coords → `"<x>, <y> (floor <floor>)"` (free pick on the floor plan)
+ *
+ * Returns `""` for `null` so it can be dropped straight into a controlled
+ * input value.
+ */
+export const formatNavigationValue = (value: NavigationRequest["start"] | null): string => {
+  if (!value) return ""
+  if ("roomNumber" in value) return formatRoomLabel(value)
+  if ("id" in value) return `Node ${value.id.slice(0, 6)}`
+  return `${value.x.toFixed(2)}, ${value.y.toFixed(2)} (floor ${value.floor})`
+}
+
+export type RoomSearchResultItem = SearchResultItem & { dbId: string }
+
+/**
+ * Build a SearchResultList row from a persisted room. The row renders as:
+ * - Circular icon badge filled with the room type's pastel color and
+ *   outlined in its darkened variant (see room-types.ts).
+ * - Primary text: `roomNumber`, followed by ` • displayName` when present
+ *   (the join is done by SearchResultList).
+ * - Secondary text: the human-readable room type label (e.g. "Meeting room").
+ *
+ * `dbId` is attached so click handlers can look the room up by primary key
+ * instead of re-deriving it from `roomNumber`.
+ */
+export const roomToSearchResultItem = (room: PersistedRoom): RoomSearchResultItem => {
+  const meta = getRoomTypeMeta(room.type)
+  const outline = getRoomTypeOutline(room.type)
+  const Icon = meta.icon
+  return {
+    id: room.roomNumber,
+    icon: <Icon className="w-5 h-5" style={{ color: outline }} />,
+    iconBgStyle: { backgroundColor: meta.color, outline: `2px solid ${outline}` },
+    title: room.displayName ?? "",
+    type: meta.label,
+    dbId: room.id,
+  }
+}

--- a/src/lib/room-types.ts
+++ b/src/lib/room-types.ts
@@ -49,7 +49,7 @@ interface RoomTypeMeta {
   icon: LucideIcon
 }
 
-export const ROOM_TYPE_META: Record<RoomType, RoomTypeMeta> = {
+const ROOM_TYPE_META: Record<RoomType, RoomTypeMeta> = {
   DEFAULT: { label: "Default", color: "#64748b", icon: Building2 },
 
   // Workspace & education
@@ -100,7 +100,7 @@ export const ROOM_TYPE_META: Record<RoomType, RoomTypeMeta> = {
 
 export const ROOM_TYPES = Object.keys(ROOM_TYPE_META) as RoomType[]
 
-export const withOpacity = (hex: string, opacity = 0.5): string => {
+const withOpacity = (hex: string, opacity = 0.5): string => {
   const num = Number.parseInt(hex.slice(1), 16)
   const r = (num >> 16) & 0xff
   const g = (num >> 8) & 0xff
@@ -118,7 +118,7 @@ export const getRoomTypeMeta = (type: RoomType): RoomTypeMeta => ({
  * channel to remove (0 = unchanged, 1 = black). Used to derive a room's
  * outline color from its fill.
  */
-export const darkenHex = (hex: string, amount = 0.5): string => {
+const darkenHex = (hex: string, amount = 0.5): string => {
   const num = Number.parseInt(hex.slice(1), 16)
   const factor = 1 - amount
   const r = Math.round(((num >> 16) & 0xff) * factor)

--- a/src/lib/three-utils.ts
+++ b/src/lib/three-utils.ts
@@ -1,0 +1,57 @@
+import * as THREE from "three"
+
+import { DRAWING_LIFT, FLOOR_HEIGHT } from "#/components/threeJS/constants"
+
+/**
+ * World-space Y coordinate for a given floor index, with an optional lift
+ * above the floor plane (used by drawing primitives and markers to avoid
+ * z-fighting with the floor texture).
+ */
+export const floorToY = (floor: number, lift = 0): number => floor * FLOOR_HEIGHT + lift
+
+/**
+ * Centroid of a polygon expressed as `(x, z)` points. The floor-plane axes
+ * are kept on input/output so callers can drop the result into a three.js
+ * position alongside a separate `y` (= `floorToY(floor)`).
+ */
+export const polygonCentroid = (
+  vertices: readonly { x: number; z: number }[],
+): { x: number; z: number } => {
+  if (vertices.length === 0) return { x: 0, z: 0 }
+  let sumX = 0
+  let sumZ = 0
+  for (const v of vertices) {
+    sumX += v.x
+    sumZ += v.z
+  }
+  return { x: sumX / vertices.length, z: sumZ / vertices.length }
+}
+
+/** Lift a world-space point above the floor by `amount` to avoid z-fighting. */
+export const lift = (v: THREE.Vector3, amount = DRAWING_LIFT): [number, number, number] => [
+  v.x,
+  v.y + amount,
+  v.z,
+]
+
+/** Snap a world point to the nearest grid intersection on the floor at `floorY`. */
+export const snapPointToGrid = (
+  point: THREE.Vector3,
+  spacing: number,
+  floorY: number,
+): THREE.Vector3 =>
+  new THREE.Vector3(
+    Math.round(point.x / spacing) * spacing,
+    floorY,
+    Math.round(point.z / spacing) * spacing,
+  )
+
+/**
+ * Convert a graph-node-style point in *map* coordinates `(x, y, floor)` into
+ * a three.js position tuple. Map `y` is the floor-plane forward axis, which
+ * three.js represents as `-z`; floor index is lifted into world `y`.
+ */
+export const mapPointToThree = (
+  point: { x: number; y: number; floor: number },
+  liftAmount = DRAWING_LIFT,
+): [number, number, number] => [point.x, floorToY(point.floor, liftAmount), -point.y]

--- a/src/lib/tool-registry.ts
+++ b/src/lib/tool-registry.ts
@@ -5,7 +5,7 @@ import type { LucideIcon } from "lucide-react"
 
 export type ToolId = Exclude<ActiveTool, null>
 
-export interface ToolMeta {
+interface ToolMeta {
   id: ToolId
   /** Short label shown in tooltips and as the inactive palette hint. */
   label: string

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -10,6 +10,7 @@ import { FloorSelector } from "#/components/map/user-tools/floor-selector"
 import { RenderModeToggle } from "#/components/map/user-tools/render-mode-toggle"
 import { RoomOverlayToggle } from "#/components/map/user-tools/room-overlay-toggle"
 import { EdgePanel } from "#/components/panels/edge/edge-panel"
+import { NavigationPanel } from "#/components/panels/navigation/navigation-panel"
 import { NodePanels } from "#/components/panels/node/node-panels"
 import { RoomInfoPanel } from "#/components/panels/room/room-info-panel"
 import { RoomPanels } from "#/components/panels/room/room-panels"
@@ -18,6 +19,7 @@ import { buttonVariants } from "#/components/ui/button"
 import { TooltipProvider } from "#/components/ui/tooltip"
 import { useIsLoggedIn } from "#/lib/auth-hooks"
 import { MapProvider, useMap } from "#/lib/map-context"
+import { NavigationProvider } from "#/lib/navigation-context"
 
 /**
  * Layout structure (z-stack from bottom to top):
@@ -76,15 +78,18 @@ const Layout = () => {
         </>
       )}
       <RoomInfoPanel />
+      <NavigationPanel />
     </main>
   )
 }
 
 const App = () => (
   <TooltipProvider>
-    <MapProvider>
-      <Layout />
-    </MapProvider>
+    <NavigationProvider>
+      <MapProvider>
+        <Layout />
+      </MapProvider>
+    </NavigationProvider>
   </TooltipProvider>
 )
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -10,6 +10,7 @@ import { FloorSelector } from "#/components/map/user-tools/floor-selector"
 import { RenderModeToggle } from "#/components/map/user-tools/render-mode-toggle"
 import { RoomOverlayToggle } from "#/components/map/user-tools/room-overlay-toggle"
 import { EdgePanel } from "#/components/panels/edge/edge-panel"
+import { MapPickOverlay } from "#/components/panels/navigation/map-pick-overlay"
 import { NavigationPanel } from "#/components/panels/navigation/navigation-panel"
 import { NodePanels } from "#/components/panels/node/node-panels"
 import { RoomInfoPanel } from "#/components/panels/room/room-info-panel"
@@ -19,7 +20,7 @@ import { buttonVariants } from "#/components/ui/button"
 import { TooltipProvider } from "#/components/ui/tooltip"
 import { useIsLoggedIn } from "#/lib/auth-hooks"
 import { MapProvider, useMap } from "#/lib/map-context"
-import { NavigationProvider } from "#/lib/navigation-context"
+import { NavigationProvider, useNavigation } from "#/lib/navigation-context"
 
 /**
  * Layout structure (z-stack from bottom to top):
@@ -36,7 +37,8 @@ import { NavigationProvider } from "#/lib/navigation-context"
  */
 const Layout = () => {
   const { isLoggedIn, isPending } = useIsLoggedIn()
-  const { debugMode } = useMap()
+  const { debugMode, pickingStart } = useMap()
+  const { navigationPanelOpen } = useNavigation()
   const isMobile = useIsMobile()
   const isAdmin = !isPending && isLoggedIn
   const showAdminUI = isAdmin && (!isMobile || debugMode)
@@ -46,12 +48,24 @@ const Layout = () => {
       <MapScene />
 
       <div className="pointer-events-none absolute inset-0 z-10">
-        <FuzzySearchBar className="pointer-events-auto absolute top-4 right-4 left-4 w-auto sm:right-auto sm:left-30 sm:w-90" />
+        {!pickingStart && !navigationPanelOpen && (
+          <FuzzySearchBar className="pointer-events-auto absolute top-4 right-4 left-4 w-auto sm:right-auto sm:left-30 sm:w-90" />
+        )}
 
-        <div className="pointer-events-auto absolute right-6 bottom-6 flex flex-col gap-2">
+        <div
+          className={`pointer-events-auto absolute flex flex-col gap-2 ${
+            pickingStart ? "right-6 bottom-28" : "right-6 bottom-6"
+          } ${
+            // Desktop: shift left of the right-anchored navigation panel
+            // (md:w-88 = 22rem) so controls stay visible while it's open.
+            navigationPanelOpen && !pickingStart
+              ? "md:right-96 md:bottom-6"
+              : "md:right-6 md:bottom-6"
+          }`}
+        >
           {isAdmin && <DebugToggle />}
           <RoomOverlayToggle />
-          <RenderModeToggle />
+          {!pickingStart && <RenderModeToggle />}
           <Compass />
           <FloorSelector />
         </div>
@@ -77,8 +91,9 @@ const Layout = () => {
           <EdgePanel />
         </>
       )}
-      <RoomInfoPanel />
+      {!pickingStart && <RoomInfoPanel />}
       <NavigationPanel />
+      <MapPickOverlay />
     </main>
   )
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, Link } from "@tanstack/react-router"
+import { useEffect } from "react"
 
 import { useIsMobile } from "#/components/hooks/use-is-mobile"
 import { ActionBar } from "#/components/map/action-bar/action-bar"
@@ -37,11 +38,26 @@ import { NavigationProvider, useNavigation } from "#/lib/navigation-context"
  */
 const Layout = () => {
   const { isLoggedIn, isPending } = useIsLoggedIn()
-  const { debugMode, pickingStart } = useMap()
-  const { navigationPanelOpen } = useNavigation()
+  const { debugMode, pickingStart, activeTool, setActiveTool } = useMap()
+  const { navigationPanelOpen, setNavigationPanelOpen } = useNavigation()
   const isMobile = useIsMobile()
   const isAdmin = !isPending && isLoggedIn
   const showAdminUI = isAdmin && (!isMobile || debugMode)
+
+  // Mutual exclusion: opening the navigation panel exits any admin tool, and
+  // activating a tool closes the navigation panel. Two effects with no-op
+  // guards converge to a stable state without racing.
+  useEffect(() => {
+    if (navigationPanelOpen && activeTool !== "default") setActiveTool("default")
+  }, [navigationPanelOpen, activeTool, setActiveTool])
+  useEffect(() => {
+    if (activeTool !== "default" && navigationPanelOpen) setNavigationPanelOpen(false)
+  }, [activeTool, navigationPanelOpen, setNavigationPanelOpen])
+
+  // The bottom action bar is on screen on mobile when picking or when an
+  // admin tool is active. The right-anchored floating controls shift up
+  // to clear it. Desktop pill is short enough that no shift is needed.
+  const actionBarVisible = pickingStart || activeTool !== "default"
 
   return (
     <main className="relative h-dvh w-full overflow-hidden bg-background">
@@ -54,7 +70,7 @@ const Layout = () => {
 
         <div
           className={`pointer-events-auto absolute flex flex-col gap-2 ${
-            pickingStart ? "right-6 bottom-28" : "right-6 bottom-6"
+            actionBarVisible ? "right-6 bottom-28" : "right-6 bottom-6"
           } ${
             // Desktop: shift left of the right-anchored navigation panel
             // (md:w-88 = 22rem) so controls stay visible while it's open.
@@ -79,9 +95,9 @@ const Layout = () => {
               Manage
             </Link>
             <ToolPalette className="pointer-events-auto absolute top-1/2 left-6 -translate-y-1/2" />
-            <ActionBar className="pointer-events-auto absolute bottom-6 left-1/2 -translate-x-1/2" />
           </>
         )}
+        <ActionBar />
       </div>
 
       {showAdminUI && (

--- a/src/routes/ui-demo.tsx
+++ b/src/routes/ui-demo.tsx
@@ -5,6 +5,7 @@ import { Button } from "#/components/ui/button"
 import { Input } from "#/components/ui/input"
 import { RoomTypeBadge } from "#/components/ui/room-type-badge"
 import { RoomType } from "#/generated/prisma/enums"
+import { roomToSearchResultItem } from "#/lib/room-format"
 import { getRoomTypeMeta, getRoomTypeOutline } from "#/lib/room-types"
 import { getAllRoomsData } from "#/server/room.functions"
 
@@ -43,19 +44,9 @@ const DemoPage = () => {
     void getAllRoomsData().then((rooms) => {
       setAllResults(
         rooms.map((room) => {
-          const meta = getRoomTypeMeta(room.type)
-          const outlineColor = getRoomTypeOutline(room.type)
-          const Icon = meta.icon
-          return {
-            id: room.roomNumber,
-            icon: <Icon className="w-5 h-5" style={{ color: outlineColor }} />,
-            iconBgStyle: {
-              backgroundColor: meta.color,
-              outline: `2px solid ${outlineColor}`,
-            },
-            title: room.displayName ?? room.type,
-            type: `${meta.label} · Floor ${room.floor}`,
-          }
+          const item = roomToSearchResultItem(room)
+          // Demo view appends the floor number to the type label.
+          return { ...item, type: `${item.type} · Floor ${room.floor}` }
         }),
       )
     })

--- a/src/server/astar.functions.ts
+++ b/src/server/astar.functions.ts
@@ -1,55 +1,11 @@
 import { createServerFn } from "@tanstack/react-start"
-import z from "zod"
 
-import { RoomType } from "#/generated/prisma/enums"
+import { AstarInputSchema } from "#/types/navigation"
 
 import { astar } from "./astar.server"
-import { nodeTypeEnum } from "./graph.functions"
-
-const roomTypeEnum = z.enum(Object.values(RoomType) as [string, ...string[]])
-
-const nodeSchema = z.object({
-  id: z.string(),
-  x: z.number(),
-  y: z.number(),
-  z: z.number(),
-  type: nodeTypeEnum,
-  isActivated: z.boolean(),
-  createdAt: z.coerce.date(),
-  updatedAt: z.coerce.date(),
-  roomId: z.string().nullable(),
-  floor: z.number().int(),
-})
-
-const xyzSchema = z.object({
-  x: z.number(),
-  y: z.number(),
-  z: z.number(),
-})
-
-const roomSchema = z.object({
-  id: z.string(),
-  roomNumber: z.string(),
-  displayName: z.string().nullable(),
-  isActivated: z.boolean(),
-  type: roomTypeEnum,
-  createdAt: z.coerce.date(),
-  updatedAt: z.coerce.date(),
-  sectionId: z.string().nullable(),
-  floor: z.number().int(),
-  nodes: z.array(nodeSchema),
-})
-
-export const astarSchema = z.object({
-  profile: z.enum(["ACCESIBLE_ROUTE", "SIMPLE_ROUTE", "FAST_ROUTE"]),
-  dest: roomSchema,
-  start: z.union([xyzSchema, nodeSchema]),
-})
-
-export type AstarInput = z.infer<typeof astarSchema>
 
 export const astarFunction = createServerFn({ method: "GET" })
-  .inputValidator(astarSchema)
+  .inputValidator(AstarInputSchema)
   .handler(async ({ data }) => {
     return await astar(data.profile, data.dest, data.start)
   })

--- a/src/server/astar.server.ts
+++ b/src/server/astar.server.ts
@@ -1,7 +1,7 @@
 import { getGraph } from "./graph.server"
 
 import type { Edge, Node } from "#/generated/prisma/client"
-import type { AstarInput } from "./astar.functions"
+import type { AstarInput } from "#/types/navigation"
 
 const TURN_PENALTY = 1
 const TURN_ANGLE_THRESHOLD = 30 // degrees
@@ -47,14 +47,14 @@ const heuristic = (
   profile: AstarInput["profile"],
   previousEdge?: Edge,
 ): number => {
-  if (profile === "ACCESIBLE_ROUTE" && node.type === "STAIR" && previousEdge) {
+  if (profile === "ACCESSIBLE" && node.type === "STAIR" && previousEdge) {
     const fromNode = graph.nodes.get(previousEdge.fromNodeId)
     if (fromNode && fromNode.floor !== node.floor) return Infinity
   }
 
   let turnPenalty = 0
 
-  if (profile === "SIMPLE_ROUTE" && previousEdge) {
+  if (profile === "SIMPLE" && previousEdge) {
     const fromNode = graph.nodes.get(previousEdge.fromNodeId)
     const toNode = graph.nodes.get(previousEdge.toNodeId)
     if (fromNode && toNode) {
@@ -78,7 +78,7 @@ const findDestinationNode = (destRoom: AstarInput["dest"], startNode: Node): Nod
       const dist = Math.hypot(n.x - startNode.x, n.y - startNode.y, n.z - startNode.z)
       if (dist < bestDist) {
         bestDist = dist
-        bestNode = n as Node
+        bestNode = n
       }
     }
     return bestNode
@@ -101,10 +101,10 @@ export const astar = async (
   // If start position is a node
   let firstNode: Node
   if ("id" in start) {
-    firstNode = start as Node
+    firstNode = start
   } else {
     // If start position is not a node, find the closest node to the start position
-    const closest = await findClosestNode(start.x, start.y, start.z)
+    const closest = await findClosestNode(start.x, start.y, start.floor)
     if (!closest) return null
     firstNode = closest
   }

--- a/src/server/floorplan.functions.ts
+++ b/src/server/floorplan.functions.ts
@@ -3,7 +3,7 @@ import { z } from "zod"
 
 import { getFloorPlans, editFloorPlan } from "./floorplan.server"
 
-export const floorPlanEditSchema = z.object({
+const floorPlanEditSchema = z.object({
   floor: z.number(),
   calibrationScale: z.number().optional(),
   path: z.string().optional(),

--- a/src/server/floorplan.server.ts
+++ b/src/server/floorplan.server.ts
@@ -6,12 +6,6 @@ export const getFloorPlans = async () => {
   })
 }
 
-export const getFloorPlansByFloor = async (floor: number) => {
-  return await prisma.floorPlan.findUnique({
-    where: { floor },
-  })
-}
-
 export const editFloorPlan = (floor: number, calibrationScale?: number, path?: string) =>
   prisma.floorPlan.update({
     where: { floor },

--- a/src/server/graph.functions.ts
+++ b/src/server/graph.functions.ts
@@ -1,25 +1,25 @@
 import { createServerFn } from "@tanstack/react-start"
-import { z } from "zod"
 
-import { NodeType } from "#/generated/prisma/enums"
+import { CreateEdgeSchema, EdgeIdSchema } from "#/types/edge"
+import {
+  CreateNodeSchema,
+  CreateTransitNodesSchema,
+  NodeIdSchema,
+  UpdateNodeSchema,
+} from "#/types/node"
 
 import {
-  getAllNodesInDb,
-  getAllEdgesInDb,
-  updateNodeTypeInDb,
-  updateNodeInDb,
-  addNodeInDb,
-  deleteNodeByIdInDb,
   activateNodeByIdInDb,
-  deactiveNodeByIdInDb,
   addEdgeInDb,
-  deleteEdgeByIdInDb,
-  deactivateEdgeByIdinDb,
-  activateEdgeByIdInDb,
+  addNodeInDb,
   createTransitNodesInDb,
+  deactiveNodeByIdInDb,
+  deleteEdgeByIdInDb,
+  deleteNodeByIdInDb,
+  getAllEdgesInDb,
+  getAllNodesInDb,
+  updateNodeInDb,
 } from "./graph.server"
-
-export const nodeTypeEnum = z.enum(Object.values(NodeType) as [string, ...string[]])
 
 export const getAllNodesData = createServerFn({ method: "GET" }).handler(async () => {
   return await getAllNodesInDb()
@@ -29,66 +29,20 @@ export const getAllEdgesData = createServerFn({ method: "GET" }).handler(async (
   return await getAllEdgesInDb()
 })
 
-const updateNodeTypeSchema = z.object({
-  id: z.string().min(1),
-  type: nodeTypeEnum,
-})
-
-export const updateNodeTypeData = createServerFn({ method: "POST" })
-  .inputValidator(updateNodeTypeSchema)
-  .handler(async ({ data }) => {
-    return await updateNodeTypeInDb(data.id, data.type)
-  })
-
-const updateNodeSchema = z.object({
-  id: z.string().min(1),
-  type: nodeTypeEnum,
-  x: z.number(),
-  y: z.number(),
-})
-
 export const updateNodeData = createServerFn({ method: "POST" })
-  .inputValidator(updateNodeSchema)
+  .inputValidator(UpdateNodeSchema)
   .handler(async ({ data }) => {
     return await updateNodeInDb(data.id, { type: data.type, x: data.x, y: data.y })
   })
 
-export const addNodeSchema = z.object({
-  x: z.number(),
-  y: z.number(),
-  z: z.number(),
-  type: nodeTypeEnum,
-  floor: z.number().int(),
-  isActivated: z.boolean().optional(),
-  roomId: z.string().optional(),
-})
-
-export const nodeIdSchema = z.object({
-  id: z.string().min(1),
-})
-
-export const addEdgeSchema = z.object({
-  fromNodeId: z.string().min(1),
-  toNodeId: z.string().min(1),
-  distance: z.number().positive(),
-  doors: z.boolean().optional(),
-  stairs: z.boolean().optional(),
-  elevators: z.boolean().optional(),
-  isActivated: z.boolean().optional(),
-})
-
-export const edgeIdSchema = z.object({
-  id: z.string().min(1),
-})
-
 export const addNodeData = createServerFn({ method: "POST" })
-  .inputValidator(addNodeSchema)
+  .inputValidator(CreateNodeSchema)
   .handler(async ({ data }) => {
     return await addNodeInDb({
       x: data.x,
       y: data.y,
       z: data.z,
-      type: data.type as NodeType,
+      type: data.type,
       isActivated: data.isActivated ?? true,
       room: data.roomId ? { connect: { id: data.roomId } } : undefined,
       floorPlan: { connect: { floor: data.floor } },
@@ -96,25 +50,25 @@ export const addNodeData = createServerFn({ method: "POST" })
   })
 
 export const deleteNodeData = createServerFn({ method: "POST" })
-  .inputValidator(nodeIdSchema)
+  .inputValidator(NodeIdSchema)
   .handler(async ({ data }) => {
     return await deleteNodeByIdInDb(data.id)
   })
 
 export const activateNodeData = createServerFn({ method: "POST" })
-  .inputValidator(nodeIdSchema)
+  .inputValidator(NodeIdSchema)
   .handler(async ({ data }) => {
     return await activateNodeByIdInDb(data.id)
   })
 
 export const deactivateNodeData = createServerFn({ method: "POST" })
-  .inputValidator(nodeIdSchema)
+  .inputValidator(NodeIdSchema)
   .handler(async ({ data }) => {
     return await deactiveNodeByIdInDb(data.id)
   })
 
 export const addEdgeData = createServerFn({ method: "POST" })
-  .inputValidator(addEdgeSchema)
+  .inputValidator(CreateEdgeSchema)
   .handler(async ({ data }) => {
     return await addEdgeInDb({
       distance: data.distance,
@@ -128,35 +82,13 @@ export const addEdgeData = createServerFn({ method: "POST" })
   })
 
 export const deleteEdgeData = createServerFn({ method: "POST" })
-  .inputValidator(edgeIdSchema)
+  .inputValidator(EdgeIdSchema)
   .handler(async ({ data }) => {
     return await deleteEdgeByIdInDb(data.id)
   })
 
-export const deactivateEdgeData = createServerFn({ method: "POST" })
-  .inputValidator(edgeIdSchema)
-  .handler(async ({ data }) => {
-    return await deactivateEdgeByIdinDb(data.id)
-  })
-
-export const activateEdgeData = createServerFn({ method: "POST" })
-  .inputValidator(edgeIdSchema)
-  .handler(async ({ data }) => {
-    return await activateEdgeByIdInDb(data.id)
-  })
-
-const createTransitNodesSchema = z.object({
-  x: z.number(),
-  y: z.number(),
-  z: z.number(),
-  type: z.enum(["STAIR", "ELEVATOR"]),
-  floors: z.array(z.number().int()).min(1),
-  isActivated: z.boolean().optional(),
-  roomId: z.string().optional(),
-})
-
 export const createTransitNodesData = createServerFn({ method: "POST" })
-  .inputValidator(createTransitNodesSchema)
+  .inputValidator(CreateTransitNodesSchema)
   .handler(async ({ data }) => {
     return await createTransitNodesInDb({
       x: data.x,

--- a/src/server/graph.server.ts
+++ b/src/server/graph.server.ts
@@ -7,7 +7,7 @@ const FLOOR_HEIGHT_METERS = 3.25
 
 let graph: Graph | null = null
 
-export class Graph {
+class Graph {
   nodes: Map<Node["id"], Node>
   adjacency: Map<Node["id"], Edge[]>
 
@@ -205,17 +205,6 @@ export const getAllEdgesInDb = async () => {
   return await prisma.edge.findMany()
 }
 
-export const updateNodeTypeInDb = async (nodeId: string, type: string) => {
-  const updated = await prisma.node.update({
-    where: { id: nodeId },
-    data: { type: type as Node["type"] },
-  })
-  const g = await getGraph()
-  const node = g.nodes.get(nodeId)
-  if (node) node.type = updated.type
-  return updated
-}
-
 export const updateNodeInDb = async (
   nodeId: string,
   data: { type: string; x: number; y: number },
@@ -317,30 +306,6 @@ export const deleteEdgeByIdInDb = async (edgeId: Edge["id"]) => {
   g.deleteEdgeByNodeIds(deleted.fromNodeId, deleted.toNodeId)
 
   return deleted
-}
-
-export const deactivateEdgeByIdinDb = async (edgeId: Edge["id"]) => {
-  const updated = await prisma.edge.update({
-    where: { id: edgeId },
-    data: { isActivated: false },
-  })
-
-  const g = await getGraph()
-  g.deactiveEdgeByNodeIds(updated.fromNodeId, updated.toNodeId)
-
-  return updated
-}
-
-export const activateEdgeByIdInDb = async (edgeId: Edge["id"]) => {
-  const updated = await prisma.edge.update({
-    where: { id: edgeId },
-    data: { isActivated: true },
-  })
-
-  const g = await getGraph()
-  g.activateEdgeByNodeIds(updated.fromNodeId, updated.toNodeId)
-
-  return updated
 }
 
 export const createTransitNodesInDb = async (input: {

--- a/src/server/room.functions.ts
+++ b/src/server/room.functions.ts
@@ -1,40 +1,11 @@
 import { createServerFn } from "@tanstack/react-start"
-import { z } from "zod"
 
-import { ROOM_TYPES } from "../lib/room-types"
+import { CreateRoomSchema, RoomIdSchema, UpdateRoomMetadataSchema } from "#/types/room"
 
 import { createRoom, deleteRoom, getAllRooms, updateRoomMetadata } from "./room.server"
 
-const roomTypeEnum = z.enum(ROOM_TYPES)
-
-export const createRoomSchema = z.object({
-  roomNumber: z.string().min(1).max(100),
-  displayName: z.string().max(200).optional(),
-  type: roomTypeEnum,
-  floor: z.number().int(),
-  vertices: z
-    .array(
-      z.object({
-        x: z.number(),
-        z: z.number(),
-      }),
-    )
-    .min(3),
-})
-
-export const updateRoomMetadataSchema = z.object({
-  id: z.string().min(1),
-  roomNumber: z.string().min(1).max(100),
-  displayName: z.string().max(200).optional(),
-  type: roomTypeEnum,
-})
-
-export const deleteRoomSchema = z.object({
-  id: z.string().min(1),
-})
-
 export const createRoomData = createServerFn({ method: "POST" })
-  .inputValidator(createRoomSchema)
+  .inputValidator(CreateRoomSchema)
   .handler(async ({ data }) => {
     return await createRoom(data)
   })
@@ -44,13 +15,13 @@ export const getAllRoomsData = createServerFn({ method: "GET" }).handler(async (
 })
 
 export const updateRoomMetadataData = createServerFn({ method: "POST" })
-  .inputValidator(updateRoomMetadataSchema)
+  .inputValidator(UpdateRoomMetadataSchema)
   .handler(async ({ data }) => {
     return await updateRoomMetadata(data)
   })
 
 export const deleteRoomData = createServerFn({ method: "POST" })
-  .inputValidator(deleteRoomSchema)
+  .inputValidator(RoomIdSchema)
   .handler(async ({ data }) => {
     return await deleteRoom(data.id)
   })

--- a/src/server/room.server.ts
+++ b/src/server/room.server.ts
@@ -2,39 +2,8 @@ import crypto from "node:crypto"
 
 import { prisma } from "#/db"
 
-import type { RoomType } from "#/generated/prisma/enums"
-
-/**
- * A polygon vertex in the floor's local 2D frame, projected from a
- * THREE.Vector3 (where x is the floor's right axis and z is the floor's
- * forward axis — three.js Y is the floor stacking dimension and is dropped).
- */
-export interface RoomVertex {
-  x: number
-  z: number
-}
-
-export interface CreateRoomInput {
-  roomNumber: string
-  displayName?: string
-  type: RoomType
-  floor: number
-  vertices: RoomVertex[]
-}
-
-export interface PersistedRoom {
-  id: string
-  roomNumber: string
-  displayName?: string
-  type: RoomType
-  floor: number
-  /**
-   * Exterior-ring vertices in click order, with the GeoJSON ring closure
-   * dropped (so `vertices[0] !== vertices.at(-1)`). Each entry is in the
-   * floor's local 2D frame matching the projection used by createRoom.
-   */
-  vertices: RoomVertex[]
-}
+import type { RoomType } from "#/types/enums"
+import type { CreateRoom, Room, RoomVertex, UpdateRoomMetadata } from "#/types/room"
 
 /**
  * Build a PostGIS-compatible WKT POLYGON ring from in-floor 2D vertices.
@@ -64,7 +33,7 @@ const buildPolygonWkt = (vertices: RoomVertex[]): string => {
  * Throws on validation failure with a human-readable message that the
  * client can surface in the metadata panel.
  */
-export const createRoom = async (input: CreateRoomInput): Promise<{ id: string }> => {
+export const createRoom = async (input: CreateRoom): Promise<{ id: string }> => {
   const { roomNumber, displayName, type, floor, vertices } = input
 
   if (vertices.length < 3) {
@@ -151,7 +120,7 @@ export const createRoom = async (input: CreateRoomInput): Promise<{ id: string }
 interface RoomGeoJsonRow {
   id: string
   roomNumber: string
-  displayName?: string
+  displayName: string | null
   type: RoomType
   floor: number
   polygonJson: string
@@ -172,7 +141,7 @@ interface PolygonGeoJson {
  * the last coordinate equals the first) is dropped on the way out so the
  * vertices array matches the same shape as createRoom's input.
  */
-export const getAllRooms = async (): Promise<PersistedRoom[]> => {
+export const getAllRooms = async (): Promise<Room[]> => {
   // ST_AsGeoJSON's default precision is 9 decimal digits, which truncates
   // double-precision coordinates and breaks bit-exact snap behavior on the
   // client (a snapped vertex no longer matches the existing corner once
@@ -210,13 +179,6 @@ export const getAllRooms = async (): Promise<PersistedRoom[]> => {
   })
 }
 
-export interface UpdateRoomMetadataInput {
-  id: string
-  roomNumber: string
-  displayName?: string
-  type: RoomType
-}
-
 /**
  * Update only the metadata of a room. Polygon geometry is left untouched —
  * polygon editing is a separate concern (out of scope for this PBI).
@@ -224,9 +186,7 @@ export interface UpdateRoomMetadataInput {
  * Uses the typed Prisma client (no raw SQL) since none of the updated fields
  * are PostGIS-typed.
  */
-export const updateRoomMetadata = async (
-  input: UpdateRoomMetadataInput,
-): Promise<{ id: string }> => {
+export const updateRoomMetadata = async (input: UpdateRoomMetadata): Promise<{ id: string }> => {
   await prisma.room.update({
     where: { id: input.id },
     data: {

--- a/src/types/edge.ts
+++ b/src/types/edge.ts
@@ -1,0 +1,14 @@
+import { z } from "zod"
+
+/** Server input for creating an edge between two nodes. */
+export const CreateEdgeSchema = z.object({
+  fromNodeId: z.string().min(1),
+  toNodeId: z.string().min(1),
+  distance: z.number().positive(),
+  doors: z.boolean().optional(),
+  stairs: z.boolean().optional(),
+  elevators: z.boolean().optional(),
+  isActivated: z.boolean().optional(),
+})
+
+export const EdgeIdSchema = z.object({ id: z.string().min(1) })

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -1,0 +1,13 @@
+import { z } from "zod"
+
+import { NodeType, RoomType } from "#/generated/prisma/enums"
+
+/**
+ * Zod schemas for the Prisma-generated enums. Using `z.nativeEnum` keeps the
+ * literal narrowing on the values (so `z.infer<typeof RoomTypeSchema>` is the
+ * RoomType union, not just `string`).
+ */
+export const RoomTypeSchema = z.enum(RoomType)
+export const NodeTypeSchema = z.enum(NodeType)
+
+export { type RoomType } from "#/generated/prisma/enums"

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -1,0 +1,59 @@
+import { z } from "zod"
+
+import { RoomTypeSchema } from "./enums"
+import { NodeSchema } from "./node"
+
+/**
+ * Routing preferences offered to the user. Single source of truth — the UI,
+ * the navigation context, and the A* server function all reference these
+ * literals (no separate "_ROUTE" suffixes, no misspellings).
+ */
+const RoutePreferenceSchema = z.enum(["SIMPLE", "FAST", "ACCESSIBLE"])
+export type RoutePreference = z.infer<typeof RoutePreferenceSchema>
+
+/**
+ * A free-form coordinate the user picked on the map (no node, no room — just
+ * a point). Stored in *map* coordinates so it has the same shape as `Node`
+ * and can flow through the same conversion helpers.
+ */
+const MapPickedPointSchema = z.object({
+  x: z.number(),
+  y: z.number(),
+  floor: z.number().int(),
+})
+export type MapPickedPoint = z.infer<typeof MapPickedPointSchema>
+
+/**
+ * Where the user is starting from. Either a specific graph node, or a
+ * free-form coordinate the user dropped on the map. A room is *not* a valid
+ * start — the user must pick a representative point inside one.
+ */
+const NavigationStartSchema = z.union([NodeSchema, MapPickedPointSchema])
+export type NavigationStart = z.infer<typeof NavigationStartSchema>
+
+/**
+ * The room shape A* expects for a destination: identity + nodes belonging
+ * to the room. Shaped to match the Prisma row + nodes relation so the
+ * caller can pass a Prisma `findUnique({ include: { nodes: true } })`
+ * result straight through.
+ */
+const AstarDestinationSchema = z.object({
+  id: z.string(),
+  roomNumber: z.string(),
+  displayName: z.string().nullable(),
+  isActivated: z.boolean(),
+  type: RoomTypeSchema,
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+  sectionId: z.string().nullable(),
+  floor: z.number().int(),
+  nodes: z.array(NodeSchema),
+})
+
+/** Wire shape for an A* request. */
+export const AstarInputSchema = z.object({
+  profile: RoutePreferenceSchema,
+  dest: AstarDestinationSchema,
+  start: NavigationStartSchema,
+})
+export type AstarInput = z.infer<typeof AstarInputSchema>

--- a/src/types/node.ts
+++ b/src/types/node.ts
@@ -1,0 +1,69 @@
+import { z } from "zod"
+
+import { NodeTypeSchema } from "./enums"
+
+/**
+ * A graph node, mirroring the Prisma `Node` row 1:1. `(x, y)` are the
+ * floor-plane coordinates in this floor's local frame; `z` is reserved for
+ * future use by transit nodes (currently unused by the renderer); `floor`
+ * is the floor index.
+ */
+export const NodeSchema = z.object({
+  id: z.string(),
+  x: z.number(),
+  y: z.number(),
+  z: z.number(),
+  type: NodeTypeSchema,
+  isActivated: z.boolean(),
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+  roomId: z.string().nullable(),
+  floor: z.number().int(),
+})
+export type Node = z.infer<typeof NodeSchema>
+
+/** Server input for creating a node. */
+export const CreateNodeSchema = z.object({
+  x: z.number(),
+  y: z.number(),
+  z: z.number(),
+  type: NodeTypeSchema,
+  floor: z.number().int(),
+  isActivated: z.boolean().optional(),
+  roomId: z.string().optional(),
+})
+
+/** Server input for updating a node's metadata + position. */
+export const UpdateNodeSchema = z.object({
+  id: z.string().min(1),
+  type: NodeTypeSchema,
+  x: z.number(),
+  y: z.number(),
+})
+
+export const NodeIdSchema = z.object({ id: z.string().min(1) })
+
+/**
+ * A node draft held in the UI before it's persisted. Same shape as a
+ * `CreateNode` input plus the link back to the source room (if the user
+ * dropped the pin inside one).
+ */
+const PendingNodeSchema = z.object({
+  x: z.number(),
+  y: z.number(),
+  z: z.number(),
+  floor: z.number().int(),
+  roomId: z.string().optional(),
+})
+export type PendingNode = z.infer<typeof PendingNodeSchema>
+
+/** Server input for creating a transit (stair / elevator) chain across floors. */
+export const CreateTransitNodesSchema = z.object({
+  x: z.number(),
+  y: z.number(),
+  z: z.number(),
+  type: z.enum(["STAIR", "ELEVATOR"]),
+  floors: z.array(z.number().int()).min(1),
+  isActivated: z.boolean().optional(),
+  roomId: z.string().optional(),
+})

--- a/src/types/node.ts
+++ b/src/types/node.ts
@@ -48,6 +48,7 @@ export const NodeIdSchema = z.object({ id: z.string().min(1) })
  * `CreateNode` input plus the link back to the source room (if the user
  * dropped the pin inside one).
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const PendingNodeSchema = z.object({
   x: z.number(),
   y: z.number(),

--- a/src/types/room.ts
+++ b/src/types/room.ts
@@ -1,0 +1,53 @@
+import { z } from "zod"
+
+import { RoomTypeSchema } from "./enums"
+
+/**
+ * A single polygon vertex in a floor's local 2D frame. `x` is the right
+ * axis, `z` is the forward axis (matching the three.js floor plane). Three.js
+ * `y` is the floor stacking dimension and is not stored here.
+ */
+const RoomVertexSchema = z.object({
+  x: z.number(),
+  z: z.number(),
+})
+export type RoomVertex = z.infer<typeof RoomVertexSchema>
+
+/**
+ * A room as the client knows it: identity + metadata + the polygon ring.
+ * The exterior ring is open (no duplicated closing vertex).
+ *
+ * NOTE: this is the polygon view used by the UI. A* needs a different view
+ * that includes the room's nodes — see `AstarInputSchema` in
+ * `types/navigation.ts`.
+ */
+const RoomSchema = z.object({
+  id: z.string(),
+  roomNumber: z.string(),
+  displayName: z.string().nullable(),
+  type: RoomTypeSchema,
+  floor: z.number().int(),
+  vertices: z.array(RoomVertexSchema),
+})
+export type Room = z.infer<typeof RoomSchema>
+
+/** Server input for creating a new room. */
+export const CreateRoomSchema = z.object({
+  roomNumber: z.string().min(1).max(100),
+  displayName: z.string().max(200).nullable().optional(),
+  type: RoomTypeSchema,
+  floor: z.number().int(),
+  vertices: z.array(RoomVertexSchema).min(3),
+})
+export type CreateRoom = z.infer<typeof CreateRoomSchema>
+
+/** Server input for updating a room's metadata (polygon untouched). */
+export const UpdateRoomMetadataSchema = z.object({
+  id: z.string().min(1),
+  roomNumber: z.string().min(1).max(100),
+  displayName: z.string().max(200).nullable().optional(),
+  type: RoomTypeSchema,
+})
+export type UpdateRoomMetadata = z.infer<typeof UpdateRoomMetadataSchema>
+
+export const RoomIdSchema = z.object({ id: z.string().min(1) })

--- a/src/types/room.ts
+++ b/src/types/room.ts
@@ -21,6 +21,7 @@ export type RoomVertex = z.infer<typeof RoomVertexSchema>
  * that includes the room's nodes — see `AstarInputSchema` in
  * `types/navigation.ts`.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const RoomSchema = z.object({
   id: z.string(),
   roomNumber: z.string(),


### PR DESCRIPTION
## Description

Introduces the end-user navigation flow: a **NavigationPanel** with fuzzy room search, click-to-pick on the map, free-form coordinate picking, routing preference (Simple / Fast / Accessible), and live ring markers for both endpoints. Path rendering will be a follow-up; this PR sets up the state, types, picking flows, and overlay markers so it slots in cleanly.

Along the way: one source of truth for domain types in `src/types/` (Zod-first, paired with Prisma), a shared `three-utils` module that replaces ~6 inline copies of polygon centroid / floor-to-Y math, an `ActionBar` shell that finally renders right on mobile, a unified `SearchBar` primitive, and a Knip-driven cleanup of unused exports.

Closes #, closes #, ...

## How to run

1. `pnpm dev`, open the home page.
2. Use the top search bar to find a room, click result, then "Start navigation" in the info drawer. NavigationPanel opens with that room as destination.
3. Tap the Start field. Three picking paths:
   - Type to fuzzy-search rooms (results inline)
   - "Select on map" (bullseye + bottom action bar)
   - Click any room directly on the map (same as edit-room)
4. Blue Start ring + orange Destination ring should render on the map. In 3D both visible always; in 2D only on the active floor.
5. Toggle preferences and 2D/3D, switch floors. Markers gate correctly.
6. Repeat on mobile. Pick-start bar fills the bottom edge with labelled buttons; admin tools get the same treatment instead of the old broken pill.

## Changes made

### Navigation panel and flow

- `panels/navigation/navigation-panel.tsx`: start/destination fields (shared SearchBar field variant), preference toggle, results list, "Select on map" affordance.
- `panels/navigation/navigation-panel-shared.tsx`: static config (FIELDS, FIELD_LABEL, PREFERENCE_OPTIONS, SELECT_ON_MAP_ITEM, DotConnector), following the room/node panel-shared pattern.
- `panels/navigation/map-pick-overlay.tsx`: reduced to just the bullseye crosshair (Cancel/Confirm bar moved into ActionBar).
- `lib/navigation-context.tsx`: owns `start`, `destination`, `preference`, `navigationPanelOpen`, plus `activeField` (lifted from local state) and a `pickRoomForActiveField` helper that handles the room-to-centroid conversion in one place.
- `panels/room/room-info-panel.tsx`: "Start navigation" button wires into `setDestination` + `setNavigationPanelOpen`.

### Click-on-room shortcut

- `threeJS/room-polygons-layer.tsx`: when NavigationPanel has an active field, clicking any room populates that field via `pickRoomForActiveField`. Mirrors the existing edit-room flow, no new event plumbing.

### Map markers

- `threeJS/navigation-markers.tsx`: blue Start and orange Destination rings at the chosen point or room centroid, each with an `<Html>` pill label. 3D: both always render. 2D: each marker only renders when its floor matches `currentFloor`. Reads off `useNavigation()` so the future path layer can consume the same state without further plumbing.

### Adaptive ActionBar shell

- `map/action-bar/action-bar.tsx`: extracted `ActionBarShell`. Mobile: full-width bottom bar. Desktop (`md+`): centered pill (existing). New `pickingStart` branch renders Cancel/Confirm inside the same shell with the hint inlined on mobile (no floating toast overlapping right-side controls).
- `map/action-bar/pill-button.tsx`: optional `prominentLabel` flag for icon+label on mobile, icon-only + tooltip on desktop. Used for Cancel/Confirm/Exit; tool actions stay icon-only.
- `routes/index.tsx`: ActionBar mounts unconditionally (was admin-gated). Right-anchored floating controls shift up whenever any action bar is on screen on mobile.

### Mutual exclusion: nav panel vs admin tools

- `routes/index.tsx`: two effects coordinate state. Opening NavigationPanel exits any active admin tool; activating a tool closes NavigationPanel. Prevents the previous overlap where both could be visible.

### Centralized core types (Prisma + `src/types/` as the only sources of truth)

- `types/enums.ts`: `RoomTypeSchema`, `NodeTypeSchema` via `z.nativeEnum`.
- `types/room.ts`: `RoomSchema`, `RoomVertexSchema`, `CreateRoomSchema`, `UpdateRoomMetadataSchema`, `RoomIdSchema`. `displayName: string | null` to match DB.
- `types/node.ts`: `NodeSchema`, `CreateNodeSchema`, `UpdateNodeSchema`, `NodeIdSchema`, `PendingNodeSchema`, `CreateTransitNodesSchema`.
- `types/edge.ts`: `CreateEdgeSchema`, `EdgeIdSchema`.
- `types/navigation.ts`: `RoutePreferenceSchema` (`"SIMPLE" | "FAST" | "ACCESSIBLE"`, fixes misspelled `"ACCESIBLE_ROUTE"`), `MapPickedPointSchema`, `NavigationStartSchema` (Node | MapPickedPoint, no Room), `AstarDestinationSchema`, `AstarInputSchema`.
- Server functions (`room.functions.ts`, `graph.functions.ts`, `astar.functions.ts`) consume these via TanStack Start's `inputValidator(...)`. Removed all local duplicates: `createRoomSchema`, `nodeSchema`, `roomSchema`, `xyzSchema`, `astarSchema`, manual enum casts.
- `lib/navigation-context.tsx` and `lib/map-context.tsx` use the central types instead of declaring local interfaces.

### Shared three-utils (`lib/three-utils.ts`)

- New: `polygonCentroid`, `floorToY`, `lift`, `snapPointToGrid`, `mapPointToThree`.
- Replaces inline copies in `room-polygons-layer` (`computeCentroid`), `navigation-markers` (`centroidOf`), `drawing-layer` and `graph-layer` (identical local `lift` + `snapPointToGrid`), and the repeated `floor * FLOOR_HEIGHT [+ DRAWING_LIFT]` math in `floor-plane`, `raycast-plane`, `connect-edge-layer`, `room-polygons-layer`.
- `mapPointToThree(node, lift?)` collapses ~6 inline `[node.x, floorY + DRAWING_LIFT, -node.y]` patterns.
- `MARKER_LIFT` constant added to `threeJS/constants.ts` (was a magic `DRAWING_LIFT * 4` literal).
- Bug fix in navigation-markers: Node branch was reading `value.z` (unrelated DB column) instead of converting `(value.x, -value.y)` to three.js space.

### Drawing primitives

- `threeJS/draw-primitives.tsx`: added `RingMarker` for navigation overlay cues (`depthTest={false}`).

### Search bar consolidation

- `ui/search-bar.tsx`: three modes (`standalone`, `integrated`, `field`) backed by a shared internal `SearchInput`.
- `map/search/fuzzy-search-bar.tsx`: uses the integrated variant.
- New shadcn primitives: `button-group.tsx`, `toggle-group.tsx`.

### Room formatting helpers (`lib/room-format.tsx`)

- `formatRoomLabel`, `formatNavigationValue`, `roomToSearchResultItem`. Replaces three near-identical inline mappings in fuzzy-search-bar, navigation-panel, and ui-demo, plus duplicated `${roomNumber} · ${displayName}` in node panels. Unified separator on `·`.

### Knip-driven cleanup

- Removed unused exports/server-fns/types: `MAX_FILE_SIZE`, `formSchema`, `NODE_TYPES`, `DEFAULT_3D_POLAR`, `useSession`, `requireSession`, `worldVectorFromMap`, `openPolylineSelfIntersection`, `closingEdgeIntersectsPolyline`, `floorPlanEditSchema`, `getFloorPlansByFloor`, `updateNodeTypeData`, `deactivateEdgeData`, `activateEdgeData` (+ DB-side equivalents), `EdgeSchema`/`Edge`/`CreateEdge`/`EdgeId`, `RoomId`, `NodeId`, `CreateNode`, `UpdateNode`, `UpdateNodeType`, `CreateTransitNodes`, `AstarDestination`, `PreferenceOption`, `NodeType` re-export.
- De-exported (kept internal) helpers/schemas only used in their defining file. Real Knip count went from ~48 to 4 false positives (server entry files Knip's config doesn't recognise).

### Carried in via rebase

Listed for completeness, not new in this branch:

- A* algorithm (`server/astar.{functions,server}.ts`).
- Panel folder split, responsive `<Panel />` shell with mobile bottom-sheet behaviour.
- `useIsMobile`, drag-controls fix, map-scene perf optimisations.


## UI changes (Screenshots)

### Desktop
<img width="1250" height="964" alt="image" src="https://github.com/user-attachments/assets/f17f4774-362f-4b44-9440-ab1c0b0de18d" />

<img width="1250" height="964" alt="image" src="https://github.com/user-attachments/assets/eab3c9a6-8bb7-44b5-ab8f-93bd40ee3d07" />

<img width="1250" height="964" alt="image" src="https://github.com/user-attachments/assets/7a9a7386-9bd4-4c35-bc85-dcff3464aaa6" />

<img width="1250" height="964" alt="image" src="https://github.com/user-attachments/assets/733e84dd-f33e-463d-a34a-451c62df2558" />

### Mobile

<img width="440" height="948" alt="image" src="https://github.com/user-attachments/assets/5f43e8e5-a07c-4423-89e2-9906c4ef5751" />

<img width="440" height="948" alt="image" src="https://github.com/user-attachments/assets/54bd7a44-fff1-4fc2-8ee0-8521de7265e6" />

Can be collapsed as well:

<img width="440" height="948" alt="image" src="https://github.com/user-attachments/assets/9b226656-8694-4ce8-95b7-bc2e2f2c6ab5" />

<img width="440" height="948" alt="image" src="https://github.com/user-attachments/assets/92c4fd29-b42c-4409-8e90-1c8b43c4bd5e" />


## Checklist

- [x] PR title follows the format `Feat/`, `Fix/` or `Chore/` (e.g. `Feat/Add navigation panel + start/destination picking`)
- [x] Self-assigned this PR
- [x] Added relevant labels (e.g. `feature`, `fix`, `chore`)
- [ ] Linked a PBI from GitHub Projects
- [x] Manually tested the features touched by the files changed
- [x] Project builds locally (`pnpm build`)
- [x] No unrelated changes snuck in
