### PR TITLE
Fix/ floor change camera issue

### DIFF
--- a/src/components/threeJS/map-scene.tsx
+++ b/src/components/threeJS/map-scene.tsx
@@ -38,10 +38,11 @@ export const MapScene = () => {
   const neighbourOpacityRef = useRef(0)
 
   const activeFloor = currentFloor ?? 0
-  const initialTarget = useMemo(
-    () => new THREE.Vector3(0, activeFloor * FLOOR_HEIGHT, 0),
-    [activeFloor],
-  )
+  // Mount-only: re-creating this Vector3 on floor change would make drei copy
+  // it onto controls.target, snapping x/z back to 0 and shifting the orbit
+  // pivot. CameraRig owns the per-frame y-lerp toward the active floor.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const initialTarget = useMemo(() => new THREE.Vector3(0, activeFloor * FLOOR_HEIGHT, 0), [])
 
   // OrbitControls has built-in modifier-key inversion: with LEFT=PAN, holding
   // Shift/Ctrl/Cmd while left-click-dragging swaps to ROTATE automatically


### PR DESCRIPTION
## Description

Fixes camera changing when switching floor.

Closes #, closes #, ...

## How to run

As you do

## Changes made

- Memoize initialTarget ONLY on component mount to let CameraRig handle it for other changes

<OrbitControls> was receiving a new target Vector3 on every floor change (the useMemo had activeFloor in its deps).  Drei copies the target prop onto controls.target whenever  the reference changes, hard-writing all three axes;  so switching floors snapped target.x/target.z back to the  world origin. Visible symptoms: the view re-centered on origin, and the apparent rotation shifted (since OrbitControls orientation is camera-relative-to-target, moving the pivot rotates the view).

This also fought CameraRig's smooth target.y lerp, which focus-rig.tsx already documents as the sole intended owner of floor transitions.

Fix: make initialTarget mount-only (useMemo(..., [])). Each axis now has one writer - pan/FocusRig own x/z, CameraRig owns y - and floor changes glide smoothly without disturbing pan or rotation.

## UI changes (Screenshots)

<!-- If this PR includes visual changes, add screenshots or recordings here. Delete this section if not applicable. -->

## Checklist

- [x] PR title follows the format `Feat/`, `Fix/` or `Chore/` (e.g. `Feat/Add A* pathfinding`)
- [x] Self-assigned this PR
- [x] Added relevant labels (e.g. `feature`, `fix`, `chore`)
- [ ] Linked a PBI from GitHub Projects
- [x] Manually tested the features touched by the files changed
- [x] Project builds locally (`pnpm build`)
- [x] No unrelated changes snuck in
