### PR TITLE
Update navigation-markers.tsx

### DIFF
--- a/src/components/panels/room/room-info-panel.tsx
+++ b/src/components/panels/room/room-info-panel.tsx
@@ -8,8 +8,9 @@ import { useMap } from "#/lib/map-context"
 import { useNavigation } from "#/lib/navigation-context"
 import { getAllRoomsData } from "#/server/room.functions"
 
-import type { Room } from "#/types/room"
 import type { ReactNode } from "react"
+
+import type { Room } from "#/types/room"
 
 /**
  * `Room` today only has `roomNumber/displayName/type/floor/vertices`, but the

--- a/src/components/panels/room/room-info-panel.tsx
+++ b/src/components/panels/room/room-info-panel.tsx
@@ -7,8 +7,8 @@ import { RoomTypeBadge } from "#/components/ui/room-type-badge"
 import { useMap } from "#/lib/map-context"
 import { useNavigation } from "#/lib/navigation-context"
 import { getAllRoomsData } from "#/server/room.functions"
-import type { Room } from "#/types/room"
 
+import type { Room } from "#/types/room"
 import type { ReactNode } from "react"
 
 /**

--- a/src/components/panels/room/room-info-panel.tsx
+++ b/src/components/panels/room/room-info-panel.tsx
@@ -7,10 +7,9 @@ import { RoomTypeBadge } from "#/components/ui/room-type-badge"
 import { useMap } from "#/lib/map-context"
 import { useNavigation } from "#/lib/navigation-context"
 import { getAllRoomsData } from "#/server/room.functions"
+import type { Room } from "#/types/room"
 
 import type { ReactNode } from "react"
-
-import type { Room } from "#/types/room"
 
 /**
  * `Room` today only has `roomNumber/displayName/type/floor/vertices`, but the

--- a/src/components/threeJS/navigation-markers.tsx
+++ b/src/components/threeJS/navigation-markers.tsx
@@ -49,14 +49,26 @@ const navigationValueToPlacement = (value: NavigationStart | Room): MarkerPlacem
  * marker doesn't project onto an unrelated floor's plan.
  */
 export const NavigationMarkers = () => {
-  const { start, destination } = useNavigation()
+  const { start, destination, navigationPath } = useNavigation()
   const { renderMode, currentFloor } = useMap()
 
-  const startPlacement = useMemo(() => (start ? navigationValueToPlacement(start) : null), [start])
-  const destinationPlacement = useMemo(
-    () => (destination ? navigationValueToPlacement(destination) : null),
-    [destination],
-  )
+  const startPlacement = useMemo(() => {
+    if (!start) return null
+    if (navigationPath && navigationPath.length > 0) {
+      const firstNode = navigationPath[0]
+      return { position: mapPointToThree(firstNode, MARKER_LIFT), floor: firstNode.floor }
+    }
+    return navigationValueToPlacement(start)
+  }, [start, navigationPath])
+
+  const destinationPlacement = useMemo(() => {
+    if (!destination) return null
+    if (navigationPath && navigationPath.length > 0) {
+      const lastNode = navigationPath[navigationPath.length - 1]
+      return { position: mapPointToThree(lastNode, MARKER_LIFT), floor: lastNode.floor }
+    }
+    return navigationValueToPlacement(destination)
+  }, [destination, navigationPath])
 
   const isVisibleOnCurrentView = (placement: MarkerPlacement) =>
     renderMode === "3d" || placement.floor === currentFloor

--- a/src/lib/map-context.tsx
+++ b/src/lib/map-context.tsx
@@ -256,21 +256,24 @@ export const MapProvider = ({ children }: { children: ReactNode }) => {
         if (v.z < minZ) minZ = v.z
         if (v.z > maxZ) maxZ = v.z
       }
-      // World-units to fit on the smaller viewport axis. 1.6× pad on the
-      // longest side keeps the room comfortably framed instead of edge-to-
-      // edge. FocusRig converts this to the right zoom (ortho) or distance
-      // (perspective) using the camera's actual frustum.
+      // World-units to fit on the smaller viewport axis. Use a larger padding
+      // factor so room search/selection doesn't zoom in as tightly.
       const longest = Math.max(maxX - minX, maxZ - minZ, 1)
-      focusRequestRef.current = { worldX: c.x, worldZ: c.z, targetSpan: longest * 1.6 }
+      focusRequestRef.current = {
+        worldX: c.x,
+        worldZ: c.z,
+        targetSpan: Math.max(longest * 2.4, 12),
+      }
       return
     }
 
     // Node or free-form point — both expose (x, y, floor) in map coords;
-    // map y → world -z. ~8m around the point is a sensible close-up.
+    // map y → world -z. Use a softer close-up so choosing a start location
+    // doesn't feel overly zoomed-in.
     focusRequestRef.current = {
       worldX: target.x,
       worldZ: -target.y,
-      targetSpan: 8,
+      targetSpan: 40,
     }
   }, [])
 


### PR DESCRIPTION
## Description
Made the navigation markers snap to start and end node, such that the rendered route actually starts and ends on the markers. Also made the zoom not as near when snapping to a room.

<!-- What does this PR do and why? Link the PBI from GitHub Projects below. -->

Closes #, closes #, ...

## How to run

<!-- If this PR introduces something non-obvious to test, briefly describe how to reach/trigger it. -->

## Changes made

- Changed navigation icons to snap to the actual nodes that navigation goes from and to. As well as the zoom when snapping to a room.

## UI changes (Screenshots)

<!-- If this PR includes visual changes, add screenshots or recordings here. Delete this section if not applicable. -->
<img width="615" height="292" alt="image" src="https://github.com/user-attachments/assets/d1153fe9-7d07-40f2-84b6-fa3d0b5ad366" />
<img width="693" height="429" alt="image" src="https://github.com/user-attachments/assets/22a12a45-8e3f-4b78-990b-5fd1fe6f179c" />

## Checklist

- [x] PR title follows the format `Feat/`, `Fix/` or `Chore/` (e.g. `Feat/Add A* pathfinding`)
- [x] Self-assigned this PR
- [x] Added relevant labels (e.g. `feature`, `fix`, `chore`)
- [ ] Linked a PBI from GitHub Projects
- [x] Manually tested the features touched by the files changed
- [x] Project builds locally (`pnpm build`)
- [x] No unrelated changes snuck in
