### PR TITLE
Fix camera clip issue

### DIFF
--- a/src/components/map/user-tools/debug-toggle.tsx
+++ b/src/components/map/user-tools/debug-toggle.tsx
@@ -7,17 +7,11 @@ interface DebugToggleProps {
 }
 
 export const DebugToggle = ({ className }: DebugToggleProps) => {
-  const { debugMode, setDebugMode, renderMode, isSelectingFloor } = useMap()
-
-  const isDisabled = renderMode === "3d"
+  const { debugMode, setDebugMode, isSelectingFloor } = useMap()
 
   if (isSelectingFloor) return null
 
-  const tooltipLabel = isDisabled
-    ? "Debug overlay (2D only)"
-    : debugMode
-      ? "Hide debug overlay"
-      : "Show debug overlay"
+  const tooltipLabel = debugMode ? "Hide debug overlay" : "Show debug overlay"
 
   return (
     <Tooltip>
@@ -28,21 +22,16 @@ export const DebugToggle = ({ className }: DebugToggleProps) => {
             className={cn(
               "w-14 h-14 rounded-2xl backdrop-blur-sm flex items-center justify-center",
               "transition-all duration-200 shadow-xl border border-slate-700/50",
-              isDisabled
-                ? "cursor-not-allowed bg-gray-600 opacity-50"
-                : "cursor-pointer bg-primary hover:bg-secondary",
-              debugMode && !isDisabled && "ring-2 ring-red-400",
+              "cursor-pointer bg-primary hover:bg-secondary",
+              debugMode && "ring-2 ring-red-400",
               className,
             )}
             onClick={() => {
-              if (!isDisabled) {
-                setDebugMode(!debugMode)
-              }
+              setDebugMode(!debugMode)
             }}
-            disabled={isDisabled}
           >
             <span className="text-white font-semibold text-xs text-center">
-              {isDisabled ? "Debug\n(2D only)" : debugMode ? "Debug: ON" : "Debug: OFF"}
+              {debugMode ? "Debug: ON" : "Debug: OFF"}
             </span>
           </button>
         }

--- a/src/components/threeJS/camera-config.tsx
+++ b/src/components/threeJS/camera-config.tsx
@@ -1,0 +1,28 @@
+import { useFrame } from "@react-three/fiber"
+
+/** Near/far for both perspective and orthographic cameras. Tiny near keeps
+ * geometry from clipping at extreme tilt + close-zoom positions; FAR is
+ * effectively unbounded — floor plane textures can be huge (mostly
+ * transparent padding) and panning moves the camera with the orbit target,
+ * so the camera-to-far-corner distance is hard to bound a priori. The
+ * Canvas runs with `logarithmicDepthBuffer: true`, so a huge near/far
+ * ratio doesn't degrade depth precision. */
+const NEAR = 0.001
+const FAR = 1e10
+
+/**
+ * Enforces camera near/far every frame. R3F's Canvas `camera` prop is only
+ * applied at default-camera creation, and toggling `orthographic` recreates
+ * the camera with three.js defaults — which puts the far plane (default 2000)
+ * well inside this scene's world extents and clips everything past it.
+ */
+export const CameraConfig = () => {
+  useFrame(({ camera }) => {
+    if (camera.near !== NEAR || camera.far !== FAR) {
+      camera.near = NEAR
+      camera.far = FAR
+      camera.updateProjectionMatrix()
+    }
+  })
+  return null
+}

--- a/src/components/threeJS/floor-plane.tsx
+++ b/src/components/threeJS/floor-plane.tsx
@@ -5,6 +5,7 @@ import { useRef } from "react"
 import * as THREE from "three"
 
 import { worldFromPixel } from "#/lib/coordinates"
+import { useMap } from "#/lib/map-context"
 import { floorToY } from "#/lib/three-utils"
 
 import type { FloorPlan } from "#/types/floor-plan"
@@ -15,18 +16,24 @@ interface FloorPlaneProps {
   neighbourOpacityRef: React.RefObject<number>
 }
 
+/** Vertical thickness of the debug bounds slab (world units). */
+const DEBUG_SLAB_HEIGHT = 0.5
+
 /**
  * A single floor plan image rendered as a horizontal plane.
  * Active floors are fully opaque; inactive floors follow the
  * camera-tilt-based opacity from neighbourOpacityRef.
  */
 export const FloorPlane = ({ floor, active, neighbourOpacityRef }: FloorPlaneProps) => {
+  const { debugMode } = useMap()
   const texture = useTexture(floor.path)
   const materialRef = useRef<THREE.MeshBasicMaterial>(null)
   const meshRef = useRef<THREE.Mesh>(null)
 
   const image = texture.image as HTMLImageElement
   const { x: width, y: height } = worldFromPixel(image.width, image.height, floor)
+  const y = floorToY(floor.floor)
+  const debugColor = `hsl(${(floor.floor * 67) % 360}, 90%, 60%)`
 
   useFrame(() => {
     const material = materialRef.current
@@ -46,15 +53,33 @@ export const FloorPlane = ({ floor, active, neighbourOpacityRef }: FloorPlanePro
   })
 
   return (
-    <mesh ref={meshRef} rotation={[-Math.PI / 2, 0, 0]} position={[0, floorToY(floor.floor), 0]}>
-      <planeGeometry args={[width, height]} />
-      <meshBasicMaterial
-        ref={materialRef}
-        map={texture}
-        side={THREE.DoubleSide}
-        transparent
-        depthWrite={false}
-      />
-    </mesh>
+    <>
+      <mesh
+        ref={meshRef}
+        rotation={[-Math.PI / 2, 0, 0]}
+        position={[0, y, 0]}
+        // Bounding sphere is anchored at the mesh's local origin (world XZ
+        // origin), not at the user's pan target. Three.js' default frustum
+        // culling drops the entire plane when the sphere falls outside the
+        // frustum — even if visible geometry is still on-screen — so panning
+        // away from the building can erase the whole floor at once.
+        frustumCulled={false}
+      >
+        <planeGeometry args={[width, height]} />
+        <meshBasicMaterial
+          ref={materialRef}
+          map={texture}
+          side={THREE.DoubleSide}
+          transparent
+          depthWrite={false}
+        />
+      </mesh>
+      {debugMode && (
+        <lineSegments position={[0, y, 0]}>
+          <edgesGeometry args={[new THREE.BoxGeometry(width, DEBUG_SLAB_HEIGHT, height)]} />
+          <lineBasicMaterial color={debugColor} />
+        </lineSegments>
+      )}
+    </>
   )
 }

--- a/src/components/threeJS/map-scene.tsx
+++ b/src/components/threeJS/map-scene.tsx
@@ -6,6 +6,7 @@ import * as THREE from "three"
 import { useMap } from "#/lib/map-context"
 
 import { AdaptiveGrid } from "./adaptive-grid"
+import { CameraConfig } from "./camera-config"
 import { CameraRig } from "./camera-rig"
 import { ConnectEdgeLayer } from "./connect-edge-layer"
 import {
@@ -60,9 +61,9 @@ export const MapScene = () => {
 
   return (
     <Canvas
-      gl={{ antialias: true }}
+      gl={{ antialias: true, logarithmicDepthBuffer: true }}
       scene={{ background: new THREE.Color("#333") }}
-      camera={{ fov: 60, near: 0.1, far: 1000, position: [0, 50, 0], zoom: 5 }}
+      camera={{ fov: 60, near: 0.001, far: 200, position: [0, 50, 0], zoom: 5 }}
       style={{
         width: "100%",
         height: "100%",
@@ -70,6 +71,7 @@ export const MapScene = () => {
       }}
       orthographic={renderMode === "2d"}
     >
+      <CameraConfig />
       <CameraRig
         activeFloor={activeFloor}
         controlsRef={controlsRef}
@@ -85,7 +87,12 @@ export const MapScene = () => {
         enablePan
         enableZoom
         enableRotate
-        screenSpacePanning
+        // Pan along the world XZ plane instead of the screen plane. With the
+        // screen-space variant, panning while tilted drags the orbit target's
+        // Y off the active floor faster than CameraRig can lerp it back —
+        // putting the camera at unexpected heights relative to the floor
+        // planes, which manifests as clipping at oblique angles.
+        screenSpacePanning={false}
         mouseButtons={mouseButtons}
         touches={{ ONE: THREE.TOUCH.PAN, TWO: THREE.TOUCH.DOLLY_ROTATE }}
         minPolarAngle={renderMode === "2d" ? TOP_DOWN_POLAR : MIN_3D_POLAR_ANGLE}

--- a/src/components/threeJS/room-polygons-layer.tsx
+++ b/src/components/threeJS/room-polygons-layer.tsx
@@ -178,6 +178,11 @@ const RoomPolygon = ({
         geometry={geometry}
         position={[0, yFill, 0]}
         renderOrder={ROOM_RENDER_ORDER}
+        // Per-polygon bounding spheres can fall outside the frustum at
+        // oblique camera angles even when part of the polygon is on-screen,
+        // dropping rooms in clean horizontal bands. Cost of always drawing
+        // these small meshes is negligible compared to the bug.
+        frustumCulled={false}
         {...pointerHandlers}
       >
         <meshBasicMaterial


### PR DESCRIPTION
## Description

Fixes camera clipping when orbiting/rotating by setting the far distance to a very large number.

Closes #, closes #, ...

## How to run

1. Test that no floors are clipped
2. Test that panning no longer rotates
3. Test debug mode

## Changes made

- Fixed camera settings
- Added bounding box to debug mode

## UI changes (Screenshots)

## Checklist

- [x] PR title follows the format `Feat/`, `Fix/` or `Chore/` (e.g. `Feat/Add A* pathfinding`)
- [x] Self-assigned this PR
- [x] Added relevant labels (e.g. `feature`, `fix`, `chore`)
- [ ] Linked a PBI from GitHub Projects
- [x] Manually tested the features touched by the files changed
- [x] Project builds locally (`pnpm build`)
- [x] No unrelated changes snuck in
