### PR TITLE
Fix/nav ui

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "short_name": "AAU Map",
+  "short_name": "Find AAU",
   "name": "AAU Copenhagen Indoor Navigation",
   "icons": [
     {

--- a/src/components/panels/panel.tsx
+++ b/src/components/panels/panel.tsx
@@ -16,8 +16,8 @@ interface PanelProps {
   header?: ReactNode
   /** Sticky footer. Always visible while the panel is open. */
   footer?: ReactNode
-  /** Scrollable body content. */
-  children: ReactNode
+  /** Scrollable body content. If omitted, the mobile drag handle is hidden. */
+  children?: ReactNode
   /** Called when the user clicks the built-in close button. Omit to hide it. */
   onClose?: () => void
   /**
@@ -89,13 +89,17 @@ export const Panel = ({
   }, [header, footer, children])
 
   useLayoutEffect(() => {
+    // visualViewport.height shrinks when the iOS keyboard opens; innerHeight
+    // does not always update on older iOS, causing the panel to overflow.
     const update = () => {
-      setViewportPx(window.innerHeight)
+      setViewportPx(window.visualViewport?.height ?? window.innerHeight)
     }
     update()
     window.addEventListener("resize", update)
+    window.visualViewport?.addEventListener("resize", update)
     return () => {
       window.removeEventListener("resize", update)
+      window.visualViewport?.removeEventListener("resize", update)
     }
   }, [])
 
@@ -117,7 +121,9 @@ export const Panel = ({
     if (open) setHeightPx(null)
   }
 
-  const currentHeight = heightPx ?? (fullHeight ? expandedPx : collapsedPx)
+  // Always clamp to expandedPx so a stale heightPx (set before the keyboard
+  // opened and shrank the viewport) never pushes the panel header off-screen.
+  const currentHeight = Math.min(heightPx ?? (fullHeight ? expandedPx : collapsedPx), expandedPx)
 
   const handlePointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
     dragRef.current = { startY: e.clientY, startHeight: currentHeight }
@@ -157,16 +163,18 @@ export const Panel = ({
           : "pointer-events-none translate-y-full md:translate-y-0 md:translate-x-full",
       )}
     >
-      <div
-        ref={handleRef}
-        className="flex shrink-0 cursor-grab touch-none items-center justify-center py-2 active:cursor-grabbing md:hidden"
-        onPointerDown={handlePointerDown}
-        onPointerMove={handlePointerMove}
-        onPointerUp={handlePointerUp}
-        onPointerCancel={handlePointerUp}
-      >
-        <div className="h-1.5 w-12 rounded-full bg-muted-foreground/30" />
-      </div>
+      {children != null && (
+        <div
+          ref={handleRef}
+          className="flex shrink-0 cursor-grab touch-none items-center justify-center py-2 active:cursor-grabbing md:hidden"
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerUp}
+        >
+          <div className="h-1.5 w-12 rounded-full bg-muted-foreground/30" />
+        </div>
+      )}
       <div ref={headerRef} className="relative shrink-0">
         {header}
         {onClose && (

--- a/src/components/panels/room/room-info-panel.tsx
+++ b/src/components/panels/room/room-info-panel.tsx
@@ -7,6 +7,7 @@ import { RoomTypeBadge } from "#/components/ui/room-type-badge"
 import { useMap } from "#/lib/map-context"
 import { useNavigation } from "#/lib/navigation-context"
 import { getAllRoomsData } from "#/server/room.functions"
+
 import { PREFERENCE_OPTIONS } from "../navigation/navigation-panel-shared"
 
 import type { Room } from "#/types/room"

--- a/src/components/panels/room/room-info-panel.tsx
+++ b/src/components/panels/room/room-info-panel.tsx
@@ -7,7 +7,6 @@ import { RoomTypeBadge } from "#/components/ui/room-type-badge"
 import { useMap } from "#/lib/map-context"
 import { useNavigation } from "#/lib/navigation-context"
 import { getAllRoomsData } from "#/server/room.functions"
-
 import { PREFERENCE_OPTIONS } from "../navigation/navigation-panel-shared"
 
 import type { Room } from "#/types/room"

--- a/src/components/panels/room/room-info-panel.tsx
+++ b/src/components/panels/room/room-info-panel.tsx
@@ -8,8 +8,9 @@ import { useMap } from "#/lib/map-context"
 import { useNavigation } from "#/lib/navigation-context"
 import { getAllRoomsData } from "#/server/room.functions"
 
-import type { Room } from "#/types/room"
 import { PREFERENCE_OPTIONS } from "../navigation/navigation-panel-shared"
+
+import type { Room } from "#/types/room"
 
 /**
  * `Room` today only has `roomNumber/displayName/type/floor/vertices`, but the
@@ -60,7 +61,8 @@ const RouteInfoBody = ({
       <div className="flex items-center gap-2">
         <NavigationIcon className="size-4 text-popover-foreground/60" />
         <span className="text-sm text-popover-foreground">
-          {(distance / WALKING_SPEED_M_PER_S / 60).toFixed(2)} min walk
+          {Math.floor(distance / WALKING_SPEED_M_PER_S / 60)}m &nbsp;
+          {Math.round((distance / WALKING_SPEED_M_PER_S) % 60)}s walk
         </span>
       </div>
       <div className="flex items-center gap-2">

--- a/src/components/panels/room/room-info-panel.tsx
+++ b/src/components/panels/room/room-info-panel.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query"
-import { MapPin, Navigation as NavigationIcon } from "lucide-react"
+import { Layers, MapPin, Navigation as NavigationIcon, Route } from "lucide-react"
 
 import { Panel } from "#/components/panels/panel"
 import { Button } from "#/components/ui/button"
@@ -9,7 +9,7 @@ import { useNavigation } from "#/lib/navigation-context"
 import { getAllRoomsData } from "#/server/room.functions"
 
 import type { Room } from "#/types/room"
-import type { ReactNode } from "react"
+import { PREFERENCE_OPTIONS } from "../navigation/navigation-panel-shared"
 
 /**
  * `Room` today only has `roomNumber/displayName/type/floor/vertices`, but the
@@ -23,39 +23,61 @@ type RoomView = Room & {
   department?: string
 }
 
-const DetailRow = ({ label, value }: { label: string; value: ReactNode }) => (
-  <div className="flex flex-col gap-0.5">
-    <span className="text-xs font-medium uppercase tracking-wide text-popover-foreground/60">
-      {label}
-    </span>
-    <span className="text-sm text-popover-foreground">{value}</span>
-  </div>
-)
+const WALKING_SPEED_M_PER_S = 1.4
 
 const RoomInfoHeader = ({ room }: { room: RoomView }) => (
   <div className="flex flex-col gap-2 p-5 pr-14 pb-3">
     <RoomTypeBadge type={room.type} variant="pill" />
-    <h2 className="text-3xl leading-tight font-bold">{room.roomNumber}</h2>
-    <p className="text-base text-popover-foreground/80">{room.displayName}</p>
+    <div className="flex w-full items-center justify-between mt-3">
+      <h2 className="text-3xl leading-tight font-bold">{room.roomNumber}</h2>
+      <p className="text-base text-popover-foreground/80">{room.displayName}</p>
+      <div className="flex">
+        <MapPin className="size-5 text-popover-foreground/60" />
+        <span className="ml-1 text-sm text-popover-foreground/60">Floor {room.floor}</span>
+      </div>
+    </div>
   </div>
 )
 
-const RoomInfoBody = ({ room }: { room: RoomView }) => (
-  <div className="flex flex-col gap-4 border-t border-white/10 px-5 py-4">
-    {room.address !== undefined && <DetailRow label="Address" value={room.address} />}
-    {room.faculty !== undefined && <DetailRow label="Faculty" value={room.faculty} />}
-    {room.department !== undefined && <DetailRow label="Department" value={room.department} />}
-    <DetailRow
-      label="Floor"
-      value={
-        <span className="inline-flex items-center gap-1">
-          <MapPin className="size-3.5 text-popover-foreground/60" />
-          {room.floor}
+const RouteInfoBody = ({
+  distance,
+  floorChanges,
+  routingProfile,
+}: {
+  distance: number
+  floorChanges: number
+  routingProfile: string
+}) => {
+  const preference = PREFERENCE_OPTIONS.find((o) => o.value === routingProfile)
+  const PreferenceIcon = preference?.icon
+
+  return (
+    <div className="flex flex-col gap-3 border-t border-white/10 px-5 py-4">
+      <div className="flex items-center gap-2">
+        <Route className="size-4 text-popover-foreground/60" />
+        <span className="text-sm text-popover-foreground">{distance.toFixed(0)} m</span>
+      </div>
+      <div className="flex items-center gap-2">
+        <NavigationIcon className="size-4 text-popover-foreground/60" />
+        <span className="text-sm text-popover-foreground">
+          {(distance / WALKING_SPEED_M_PER_S / 60).toFixed(2)} min walk
         </span>
-      }
-    />
-  </div>
-)
+      </div>
+      <div className="flex items-center gap-2">
+        <Layers className="size-4 text-popover-foreground/60" />
+        <span className="text-sm text-popover-foreground">{floorChanges} floor change</span>
+      </div>
+      {preference && PreferenceIcon && (
+        <div className="flex items-center gap-2">
+          <PreferenceIcon className="size-4 text-popover-foreground/60" />
+          <span className="text-sm text-popover-foreground">
+            {preference.label} routing profile
+          </span>
+        </div>
+      )}
+    </div>
+  )
+}
 
 const RoomInfoFooter = ({
   onStart,
@@ -74,7 +96,7 @@ const RoomInfoFooter = ({
       onClick={hasActivePath ? onStop : onStart}
     >
       <NavigationIcon className="size-4" />
-      {hasActivePath ? "Stop navigation" : "Start navigation"}
+      {hasActivePath ? "Stop navigation" : "Choose as destination"}
     </Button>
   </div>
 )
@@ -88,8 +110,14 @@ const RoomInfoFooter = ({
  */
 export const RoomInfoPanel = () => {
   const { viewingRoomId, setViewingRoomId } = useMap()
-  const { setDestination, setNavigationPanelOpen, navigationPath, setNavigationPath, setStart } =
-    useNavigation()
+  const {
+    setDestination,
+    setNavigationPanelOpen,
+    navigationPath,
+    setNavigationPath,
+    setStart,
+    preference,
+  } = useNavigation()
 
   const { data: rooms = [] } = useQuery({
     queryKey: ["rooms"],
@@ -98,9 +126,33 @@ export const RoomInfoPanel = () => {
   })
   const room = viewingRoomId ? (rooms.find((r: Room) => r.id === viewingRoomId) as RoomView) : null
 
-  // Check if there's an active navigation path to this room
   const hasActivePath = Boolean(navigationPath && navigationPath.length > 0)
 
+  const pathStats = () => {
+    if (!navigationPath) return null
+
+    let distance = 0
+    let floorChanges = 0
+
+    for (let i = 1; i < navigationPath.length; i++) {
+      const prev = navigationPath[i - 1]
+      const curr = navigationPath[i]
+
+      // Calculate distance using Euclidean formula
+      const dx = curr.x - prev.x
+      const dy = curr.y - prev.y
+      distance += Math.sqrt(dx * dx + dy * dy)
+
+      // Count floor changes
+      if (curr.floor !== prev.floor) {
+        floorChanges++
+      }
+    }
+
+    return { distance, floorChanges }
+  }
+
+  const stats = pathStats()
   const open = room != null
 
   const handleStart = () => {
@@ -136,7 +188,13 @@ export const RoomInfoPanel = () => {
         />
       }
     >
-      {room && <RoomInfoBody room={room} />}
+      {stats && (
+        <RouteInfoBody
+          distance={stats.distance}
+          floorChanges={stats.floorChanges}
+          routingProfile={preference}
+        />
+      )}
     </Panel>
   )
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -97,7 +97,7 @@ const useStartParamHydration = () => {
  */
 const Layout = () => {
   const { isLoggedIn, isPending } = useIsLoggedIn()
-  const { debugMode, pickingStart, activeTool, setActiveTool } = useMap()
+  const { debugMode, pickingStart, activeTool, setActiveTool, viewingRoomId } = useMap()
   const { navigationPanelOpen, setNavigationPanelOpen } = useNavigation()
   const isMobile = useIsMobile()
   const isAdmin = !isPending && isLoggedIn
@@ -133,9 +133,9 @@ const Layout = () => {
           className={`pointer-events-auto absolute flex flex-col gap-2 ${
             actionBarVisible ? "right-6 bottom-28" : "right-6 bottom-6"
           } ${
-            // Desktop: shift left of the right-anchored navigation panel
-            // (md:w-88 = 22rem) so controls stay visible while it's open.
-            navigationPanelOpen && !pickingStart
+            // Desktop: shift left of the right-anchored panel (navigation or
+            // room info, both md:w-88 = 22rem) so controls stay visible.
+            (navigationPanelOpen || viewingRoomId != null) && !pickingStart
               ? "md:right-96 md:bottom-6"
               : "md:right-6 md:bottom-6"
           }`}


### PR DESCRIPTION
## Description
DOCS:
Start navigations knap omdøbes til “Choose start destination” X

Tool options når man navigerer  X

På telefon når man åbner navigation kan man ikke se lukke knappen (højde problemer overflow)
Valgt destination => man skal ikke skrulle op for at se floor og man kan se distance når man påbegynder nav 

## UI changes (Screenshots)
<img width="420" height="490" alt="image" src="https://github.com/user-attachments/assets/5e009c3d-1200-4b8e-922c-52f3494af2a0" />

## Checklist

- [ ] PR title follows the format `Feat/`, `Fix/` or `Chore/` (e.g. `Feat/Add A* pathfinding`)
- [ ] Self-assigned this PR
- [ ] Added relevant labels (e.g. `feature`, `fix`, `chore`)
- [ ] Linked a PBI from GitHub Projects
- [ ] Manually tested the features touched by the files changed
- [ ] Project builds locally (`pnpm build`)
- [ ] No unrelated changes snuck in
