### PR TITLE
Feat/ Add login/out button

### DIFF
--- a/src/components/map/user-tools/auth-toggle.tsx
+++ b/src/components/map/user-tools/auth-toggle.tsx
@@ -1,0 +1,61 @@
+import { useNavigate } from "@tanstack/react-router"
+import { LogIn, LogOut } from "lucide-react"
+
+import { useIsMobile } from "#/components/hooks/use-is-mobile"
+import { Button } from "#/components/ui/button"
+import { Tooltip, TooltipContent, TooltipTrigger } from "#/components/ui/tooltip"
+import { authClient } from "#/lib/auth-client"
+import { useIsLoggedIn } from "#/lib/auth-hooks"
+import { useMap } from "#/lib/map-context"
+
+interface AuthToggleProps {
+  className?: string
+}
+
+/**
+ * Icon button for sign-in / sign-out. When logged out, navigates to /login;
+ * when logged in, signs out in place (better-auth's session hook updates
+ * reactively, so the icon swaps without a navigation). Hidden during the
+ * floor-picker overlay to keep the column from competing with it. The
+ * tooltip is suppressed on touch viewports where it would otherwise fire on
+ * long-press.
+ */
+export const AuthToggle = ({ className }: AuthToggleProps) => {
+  const { isLoggedIn, isPending } = useIsLoggedIn()
+  const { isSelectingFloor } = useMap()
+  const isMobile = useIsMobile()
+  const navigate = useNavigate()
+
+  if (isPending || isSelectingFloor) return null
+
+  const label = isLoggedIn ? "Sign out" : "Sign in"
+  const Icon = isLoggedIn ? LogOut : LogIn
+
+  const button = (
+    <Button
+      variant="floating"
+      size="icon-xl"
+      type="button"
+      aria-label={label}
+      className={className}
+      onClick={() => {
+        if (isLoggedIn) {
+          void authClient.signOut()
+        } else {
+          void navigate({ to: "/login" })
+        }
+      }}
+    >
+      <Icon className="size-5" />
+    </Button>
+  )
+
+  if (isMobile) return button
+
+  return (
+    <Tooltip>
+      <TooltipTrigger render={button} />
+      <TooltipContent side="left">{label}</TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -7,6 +7,7 @@ import { useIsMobile } from "#/components/hooks/use-is-mobile"
 import { ActionBar } from "#/components/map/action-bar/action-bar"
 import { FuzzySearchBar } from "#/components/map/search/fuzzy-search-bar"
 import { ToolPalette } from "#/components/map/tool-palette/tool-palette"
+import { AuthToggle } from "#/components/map/user-tools/auth-toggle"
 import { Compass } from "#/components/map/user-tools/compass"
 import { DebugToggle } from "#/components/map/user-tools/debug-toggle"
 import { FloorSelector } from "#/components/map/user-tools/floor-selector"
@@ -140,6 +141,7 @@ const Layout = () => {
               : "md:right-6 md:bottom-6"
           }`}
         >
+          <AuthToggle />
           {isAdmin && <DebugToggle />}
           <RoomOverlayToggle />
           {!pickingStart && <RenderModeToggle />}

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -1,8 +1,22 @@
-import { createFileRoute } from "@tanstack/react-router"
+import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { useEffect } from "react"
 
 import { LoginForm } from "#/components/login-form"
+import { useIsLoggedIn } from "#/lib/auth-hooks"
 
 const LoginPage = () => {
+  const { isLoggedIn, isPending } = useIsLoggedIn()
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    if (!isPending && isLoggedIn) {
+      void navigate({ to: "/" })
+    }
+  }, [isPending, isLoggedIn, navigate])
+
+  // Avoid flashing the form to a user who's about to be redirected.
+  if (isPending || isLoggedIn) return null
+
   return (
     <main className="flex min-h-screen items-center justify-center px-4">
       <LoginForm className="w-full max-w-sm" />


### PR DESCRIPTION
## Description

Adds a login / out button. For now also visible on mobile, as debug mode can enable ADMIN functionality on mobile for testing / showoff.

Closes #, closes #, ...

## How to run

Try logging in and out

## Changes made

- Added `auth-toggle.tsx`
- Fixed login page to redirect to `/` IF already authenticated

## UI changes (Screenshots)

<img width="366" height="340" alt="image" src="https://github.com/user-attachments/assets/30cdd68b-3b70-4fd0-876c-cad259602e15" />


## Checklist

- [x] PR title follows the format `Feat/`, `Fix/` or `Chore/` (e.g. `Feat/Add A* pathfinding`)
- [x] Self-assigned this PR
- [x] Added relevant labels (e.g. `feature`, `fix`, `chore`)
- [ ] Linked a PBI from GitHub Projects
- [x] Manually tested the features touched by the files changed
- [x] Project builds locally (`pnpm build`)
- [x] No unrelated changes snuck in
