### PR TITLE
Navigation rendering

### DIFF
--- a/src/components/panels/navigation/navigation-panel.tsx
+++ b/src/components/panels/navigation/navigation-panel.tsx
@@ -24,11 +24,11 @@ import {
   roomToSearchResultItem,
   type RoomSearchResultItem,
 } from "#/lib/room-format"
-import type { Node } from "#/types/node"
 import { astarFunction } from "#/server/astar.functions"
 import { getRoomWithNodesData } from "#/server/room.functions"
 
 import type { RoutePreference } from "#/types/navigation"
+import type { Node } from "#/types/node"
 
 export const NavigationPanel = () => {
   const {
@@ -45,14 +45,8 @@ export const NavigationPanel = () => {
     pickRoomForActiveField,
     setNavigationPath,
   } = useNavigation()
-  const {
-    pickingStart,
-    setPickingStart,
-    setViewingRoomId,
-    focusTarget,
-    renderMode,
-    currentFloor,
-  } = useMap()
+  const { pickingStart, setPickingStart, setViewingRoomId, focusTarget, renderMode, currentFloor } =
+    useMap()
 
   const [query, setQuery] = useState("")
 
@@ -108,9 +102,7 @@ export const NavigationPanel = () => {
     if (path.length === 0) return
 
     const floorNodes =
-      renderMode === "3d"
-        ? path
-        : path.filter((node) => node.floor === currentFloor)
+      renderMode === "3d" ? path : path.filter((node) => node.floor === currentFloor)
 
     const visibleNodes = floorNodes.length > 0 ? floorNodes : [path[0]]
     const minX = Math.min(...visibleNodes.map((node) => node.x))

--- a/src/components/panels/navigation/navigation-panel.tsx
+++ b/src/components/panels/navigation/navigation-panel.tsx
@@ -24,6 +24,7 @@ import {
   roomToSearchResultItem,
   type RoomSearchResultItem,
 } from "#/lib/room-format"
+import type { Node } from "#/types/node"
 import { astarFunction } from "#/server/astar.functions"
 import { getRoomWithNodesData } from "#/server/room.functions"
 
@@ -44,7 +45,14 @@ export const NavigationPanel = () => {
     pickRoomForActiveField,
     setNavigationPath,
   } = useNavigation()
-  const { pickingStart, setPickingStart, setViewingRoomId } = useMap()
+  const {
+    pickingStart,
+    setPickingStart,
+    setViewingRoomId,
+    focusTarget,
+    renderMode,
+    currentFloor,
+  } = useMap()
 
   const [query, setQuery] = useState("")
 
@@ -96,6 +104,31 @@ export const NavigationPanel = () => {
     setPickingStart(false)
   }
 
+  const focusRouteToBounds = (path: Node[]) => {
+    if (path.length === 0) return
+
+    const floorNodes =
+      renderMode === "3d"
+        ? path
+        : path.filter((node) => node.floor === currentFloor)
+
+    const visibleNodes = floorNodes.length > 0 ? floorNodes : [path[0]]
+    const minX = Math.min(...visibleNodes.map((node) => node.x))
+    const maxX = Math.max(...visibleNodes.map((node) => node.x))
+    const minY = Math.min(...visibleNodes.map((node) => node.y))
+    const maxY = Math.max(...visibleNodes.map((node) => node.y))
+    const centerX = (minX + maxX) / 2
+    const centerY = (minY + maxY) / 2
+    const targetSpan = Math.max(maxX - minX, maxY - minY, 1) * 1.6
+
+    focusTarget({
+      x: centerX,
+      y: centerY,
+      floor: visibleNodes[0].floor,
+      targetSpan,
+    })
+  }
+
   const handleStart = async () => {
     if (!start || !destination || !setNavigationPath) return
 
@@ -115,9 +148,10 @@ export const NavigationPanel = () => {
         },
       })
 
-      // Store the path in navigation context
+      // Store the path in navigation context and focus the rendered route.
       if (path) {
         setNavigationPath(path)
+        focusRouteToBounds(path)
         // Close the navigation panel and show the room info panel
         setNavigationPanelOpen(false)
         setViewingRoomId(destination.id)

--- a/src/lib/map-context.tsx
+++ b/src/lib/map-context.tsx
@@ -18,6 +18,13 @@ type RenderMode = "2d" | "3d"
 type RoomDrawMode = "polygon" | "rectangle"
 type RoomOverlayMode = "icon" | "none"
 
+type FocusTargetPoint = {
+  x: number
+  y: number
+  floor: number
+  targetSpan?: number
+}
+
 /**
  * The currently active map-editing tool, or null if none.
  *
@@ -121,7 +128,7 @@ interface MapContextValue {
    *
    * Rooms get a fit-to-bbox zoom; nodes/points get a fixed close-up zoom.
    */
-  focusTarget: (target: Room | Node | { x: number; y: number; floor: number }) => void
+  focusTarget: (target: Room | Node | FocusTargetPoint) => void
 }
 
 /**
@@ -265,12 +272,11 @@ export const MapProvider = ({ children }: { children: ReactNode }) => {
       return
     }
 
-    // Node or free-form point — both expose (x, y, floor) in map coords;
-    // map y → world -z. ~8m around the point is a sensible close-up.
+    const pointTarget = target as FocusTargetPoint
     focusRequestRef.current = {
-      worldX: target.x,
-      worldZ: -target.y,
-      targetSpan: 8,
+      worldX: pointTarget.x,
+      worldZ: -pointTarget.y,
+      targetSpan: pointTarget.targetSpan ?? 8,
     }
   }, [])
 

--- a/src/lib/map-context.tsx
+++ b/src/lib/map-context.tsx
@@ -18,7 +18,7 @@ type RenderMode = "2d" | "3d"
 type RoomDrawMode = "polygon" | "rectangle"
 type RoomOverlayMode = "icon" | "none"
 
-type FocusTargetPoint = {
+interface FocusTargetPoint {
   x: number
   y: number
   floor: number


### PR DESCRIPTION
## Description
Made the rendering of the navigation be centered when starting the navigation, such that you can see the full route without having to zoom out yourself
<!-- What does this PR do and why? Link the PBI from GitHub Projects below. -->

Closes #, closes #, ...

## How to run

<!-- If this PR introduces something non-obvious to test, briefly describe how to reach/trigger it. -->

## Changes made

- Changed navigation, so that it zooms out and centers the rendered navigation path in view

## UI changes (Screenshots)

<!-- If this PR includes visual changes, add screenshots or recordings here. Delete this section if not applicable. -->

## Checklist

- [x] PR title follows the format `Feat/`, `Fix/` or `Chore/` (e.g. `Feat/Add A* pathfinding`)
- [x] Self-assigned this PR
- [x] Added relevant labels (e.g. `feature`, `fix`, `chore`)
- [ ] Linked a PBI from GitHub Projects
- [x] Manually tested the features touched by the files changed
- [x] Project builds locally (`pnpm build`)
- [x] No unrelated changes snuck in
