### PR TITLE
Fix/ pointerEvents

### DIFF
--- a/src/components/threeJS/room-polygons-layer.tsx
+++ b/src/components/threeJS/room-polygons-layer.tsx
@@ -196,8 +196,13 @@ const RoomPolygon = ({
       </mesh>
       <EdgePreview points={outlinePoints} color={outlineColor} lineWidth={OUTLINE_WIDTH} closed />
       {active && roomOverlayMode === "icon" && iconVisible && (
-        <Html position={[iconAnchor.x, yOutline, iconAnchor.z]} center zIndexRange={[0, 0]}>
-          <div className="pointer-events-none rounded-full bg-black/60 p-1.5 text-white">
+        <Html
+          position={[iconAnchor.x, yOutline, iconAnchor.z]}
+          center
+          zIndexRange={[0, 0]}
+          pointerEvents="none"
+        >
+          <div className="rounded-full bg-black/60 p-1.5 text-white">
             <TypeIcon className="size-4" />
           </div>
         </Html>


### PR DESCRIPTION
## Description

Fixes the issue when clicking the label icon that the event is not passed through to the polygon which triggers opening the room panel.

Closes #, closes #, ...

## How to run

<!-- If this PR introduces something non-obvious to test, briefly describe how to reach/trigger it. -->

## Changes made
See the diff

## UI changes (Screenshots)

<!-- If this PR includes visual changes, add screenshots or recordings here. Delete this section if not applicable. -->

## Checklist

- [x] PR title follows the format `Feat/`, `Fix/` or `Chore/` (e.g. `Feat/Add A* pathfinding`)
- [x] Self-assigned this PR
- [x] Added relevant labels (e.g. `feature`, `fix`, `chore`)
- [ ] Linked a PBI from GitHub Projects
- [x] Manually tested the features touched by the files changed
- [x] Project builds locally (`pnpm build`)
- [x] No unrelated changes snuck in
