### PR TITLE
Fix/nav UI mobile and penalties

### DIFF
--- a/src/components/panels/panel.tsx
+++ b/src/components/panels/panel.tsx
@@ -137,7 +137,7 @@ export const Panel = ({
   /** `min`: chrome only (no body). */
   const minPx = chromePx
   /** `half`: midpoint between `min` and `full`. */
-  const halfPx = (chrome.handle + fullPx) / 2
+  const halfPx = (chromePx + fullPx) / 2
   /** `auto`: fits body content, clamped to [min, full]. */
   const autoPx = Math.min(Math.max(chromePx + chrome.content, minPx), fullPx)
   const heightOf = (s: PanelSize) =>

--- a/src/server/astar.server.ts
+++ b/src/server/astar.server.ts
@@ -102,7 +102,9 @@ const heuristic = (
     }
   }
 
-  return Math.hypot(node.x - target.x, node.y - target.y, node.z - target.z) + turnPenalty + floorPenalty
+  return (
+    Math.hypot(node.x - target.x, node.y - target.y, node.z - target.z) + turnPenalty + floorPenalty
+  )
 }
 
 const findDestinationNode = (destRoom: AstarInput["dest"], startNode: Node): Node | null => {

--- a/src/server/astar.server.ts
+++ b/src/server/astar.server.ts
@@ -9,6 +9,7 @@ import type { AstarInput } from "#/types/navigation"
 
 const TURN_PENALTY = 1
 const TURN_ANGLE_THRESHOLD = 30 // degrees
+const FLOOR_CHANGE_PENALTY = 5
 
 const graph = await getGraph()
 
@@ -80,6 +81,7 @@ const heuristic = (
   }
 
   let turnPenalty = 0
+  let floorPenalty = 0
 
   if (profile === "SIMPLE" && previousEdge) {
     const fromNode = graph.nodes.get(previousEdge.fromNodeId)
@@ -93,7 +95,14 @@ const heuristic = (
     }
   }
 
-  return Math.hypot(node.x - target.x, node.y - target.y, node.z - target.z) + turnPenalty
+  if (previousEdge) {
+    const fromNode = graph.nodes.get(previousEdge.fromNodeId)
+    if (fromNode && fromNode.floor !== node.floor && node.floor === target.floor) {
+      floorPenalty = FLOOR_CHANGE_PENALTY
+    }
+  }
+
+  return Math.hypot(node.x - target.x, node.y - target.y, node.z - target.z) + turnPenalty + floorPenalty
 }
 
 const findDestinationNode = (destRoom: AstarInput["dest"], startNode: Node): Node | null => {


### PR DESCRIPTION
## Description

Fixed UI on mobile when starting navigation, (see screenshot) and added penalty when algorithm switches floor when it is unnecessary.

I gave a penalty of 5, it worked with the examples that i could find, but maybe it has to be higher, if you can find any route that still changes floor unnecessary.

## Changes made

- Penalty to floor change

- Updated UI on mobile

## UI changes (Screenshots)

From actual phone hosted from computer. (Tested on two different phones)
<img width="942" height="2048" alt="kK8ucxBQ" src="https://github.com/user-attachments/assets/8e7abe23-29f2-485c-a7f4-8071a47c3672" />


## Checklist

- [x] PR title follows the format `Feat/`, `Fix/` or `Chore/` (e.g. `Feat/Add A* pathfinding`)
- [x] Self-assigned this PR
- [x] Added relevant labels (e.g. `feature`, `fix`, `chore`)
- [ ] Linked a PBI from GitHub Projects
- [x] Manually tested the features touched by the files changed
- [x] Project builds locally (`pnpm build`)
- [x] No unrelated changes snuck in
