### PR TITLE
Feat/performance metrics

### DIFF
--- a/src/components/panels/navigation/navigation-panel-shared.tsx
+++ b/src/components/panels/navigation/navigation-panel-shared.tsx
@@ -1,7 +1,7 @@
-import { Accessibility, Circle, Crosshair, MapPin, Route, Zap } from "lucide-react"
+import { Accessibility, Bug, Circle, Crosshair, MapPin, Route, Zap } from "lucide-react"
 
 import type { SearchResultItem } from "#/components/ui/search-result-list"
-import type { FieldKey } from "#/lib/navigation-context"
+import type { FieldKey, NavigationDebug } from "#/lib/navigation-context"
 import type { RoutePreference } from "#/types/navigation"
 import type { LucideIcon } from "lucide-react"
 
@@ -66,3 +66,32 @@ export const DotConnector = () => (
     </div>
   </div>
 )
+
+const fmt = (n: number | null, digits = 0): string => (n === null ? "—" : n.toFixed(digits))
+
+/**
+ * Read-only debug strip rendered beneath the route summary when
+ * `MapContext.debugMode` is on. Shows only what isn't already in the
+ * user-facing route info (distance, walk time, floor changes, profile).
+ */
+export const NavigationDebugBody = ({ debug }: { debug: NavigationDebug }) => {
+  const m = debug.algorithm
+  return (
+    <div className="flex flex-col gap-2 border-t border-white/10 px-5 py-4 font-mono text-xs text-popover-foreground/80">
+      <div className="flex items-center gap-2 font-sans text-sm font-semibold text-popover-foreground">
+        <Bug className="size-4" />
+        <span>A* debug</span>
+      </div>
+      <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+        <span>algorithm</span>
+        <span className="text-right">{m.durationMs.toFixed(2)} ms</span>
+        <span>round-trip</span>
+        <span className="text-right">{debug.roundTripMs.toFixed(2)} ms</span>
+        <span>turns</span>
+        <span className="text-right">{fmt(m.turns)}</span>
+        <span>detour ratio</span>
+        <span className="text-right">{fmt(m.detourRatio, 3)}</span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/panels/navigation/navigation-panel.tsx
+++ b/src/components/panels/navigation/navigation-panel.tsx
@@ -200,6 +200,7 @@ export const NavigationPanel = () => {
         return
       }
 
+      const requestStart = performance.now()
       const path = await astarFunction({
         data: {
           profile: preference,
@@ -207,6 +208,10 @@ export const NavigationPanel = () => {
           dest: destinationWithNodes,
         },
       })
+      const roundTripMs = performance.now() - requestStart
+      console.warn(
+        `[astar] round-trip ${roundTripMs.toFixed(2)}ms profile=${preference} pathLen=${path?.length ?? "null"}`,
+      )
 
       // A* returns:
       // - `null` when the graph can't connect start to destination at all

--- a/src/components/panels/navigation/navigation-panel.tsx
+++ b/src/components/panels/navigation/navigation-panel.tsx
@@ -95,6 +95,7 @@ export const NavigationPanel = () => {
     setActiveField,
     pickRoomForActiveField,
     setNavigationPath,
+    setNavigationDebug,
   } = useNavigation()
   const { pickingStart, setPickingStart, setViewingRoomId, focusTarget, renderMode, currentFloor } =
     useMap()
@@ -201,7 +202,7 @@ export const NavigationPanel = () => {
       }
 
       const requestStart = performance.now()
-      const path = await astarFunction({
+      const { path, metrics } = await astarFunction({
         data: {
           profile: preference,
           start,
@@ -214,10 +215,10 @@ export const NavigationPanel = () => {
       )
 
       // A* returns:
-      // - `null` when the graph can't connect start to destination at all
+      // - `path: null` when the graph can't connect start to destination at all
       //   (disconnected graph, destination room has no DOOR/ENDPOINT, etc.)
-      // - `[singleNode]` when start == destination, which is truthy but not
-      //   a meaningful route. Treat both as user-visible failures rather
+      // - `path: [singleNode]` when start == destination, which is truthy but
+      //   not a meaningful route. Treat both as user-visible failures rather
       //   than silently closing the panel.
       if (!path) {
         setRouteError({ kind: "no-route", message: ROUTE_ERROR_COPY["no-route"] })
@@ -230,6 +231,7 @@ export const NavigationPanel = () => {
 
       focusRouteToBounds(path)
       setNavigationPath(path)
+      setNavigationDebug?.({ algorithm: metrics, roundTripMs })
       setNavigationPanelOpen(false)
       setViewingRoomId(destination.id)
     } catch (error) {
@@ -331,7 +333,7 @@ export const NavigationPanel = () => {
       // `auto` otherwise so the panel hugs its content (just the two
       // fields and toggle when you're picking, even tighter when you're
       // ready to start).
-      size={activeField !== null ? "full" : "auto"}
+      size={activeField === null ? "auto" : "full"}
       onClose={handleClose}
       header={header}
       footer={footer}

--- a/src/components/panels/panel.tsx
+++ b/src/components/panels/panel.tsx
@@ -137,7 +137,7 @@ export const Panel = ({
   /** `min`: chrome only (no body). */
   const minPx = chromePx
   /** `half`: midpoint between `min` and `full`. */
-  const halfPx = (chrome.handle + fullPx) / 2
+  const halfPx = (chromePx + fullPx) / 2
   /** `auto`: fits body content, clamped to [min, full]. */
   const autoPx = Math.min(Math.max(chromePx + chrome.content, minPx), fullPx)
   const heightOf = (s: PanelSize) =>

--- a/src/components/panels/room/room-info-panel.tsx
+++ b/src/components/panels/room/room-info-panel.tsx
@@ -8,7 +8,7 @@ import { useMap } from "#/lib/map-context"
 import { useNavigation } from "#/lib/navigation-context"
 import { getAllRoomsData } from "#/server/room.functions"
 
-import { PREFERENCE_OPTIONS } from "../navigation/navigation-panel-shared"
+import { NavigationDebugBody, PREFERENCE_OPTIONS } from "../navigation/navigation-panel-shared"
 
 import type { Room } from "#/types/room"
 
@@ -111,12 +111,13 @@ const RoomInfoFooter = ({
  *   handle up to reveal the body details.
  */
 export const RoomInfoPanel = () => {
-  const { viewingRoomId, setViewingRoomId } = useMap()
+  const { viewingRoomId, setViewingRoomId, debugMode } = useMap()
   const {
     setDestination,
     setNavigationPanelOpen,
     navigationPath,
     setNavigationPath,
+    navigationDebug,
     setStart,
     preference,
   } = useNavigation()
@@ -203,6 +204,7 @@ export const RoomInfoPanel = () => {
           routingProfile={preference}
         />
       )}
+      {debugMode && navigationDebug && <NavigationDebugBody debug={navigationDebug} />}
     </Panel>
   )
 }

--- a/src/lib/navigation-context.tsx
+++ b/src/lib/navigation-context.tsx
@@ -3,9 +3,17 @@ import { createContext, useCallback, useContext, useMemo, useState } from "react
 import { useMap } from "#/lib/map-context"
 import { polygonCentroid } from "#/lib/three-utils"
 
-import type { NavigationStart, RoutePreference } from "#/types/navigation"
+import type { AstarMetrics, NavigationStart, RoutePreference } from "#/types/navigation"
 import type { Node } from "#/types/node"
 import type { Room } from "#/types/room"
+
+/**
+ * Debug-only metrics collected from the most recent route computation.
+ */
+export interface NavigationDebug {
+  algorithm: AstarMetrics
+  roundTripMs: number
+}
 
 /** Which navigation panel field the user is currently editing. */
 export type FieldKey = "start" | "destination"
@@ -33,6 +41,8 @@ interface NavigationContextValue {
    */
   activeField: FieldKey | null
   navigationPath?: Node[]
+  /** Debug metrics from the most recent route. Always present when a path is. */
+  navigationDebug?: NavigationDebug
   setStart: (start: NavigationRequest["start"] | null) => void
   setDestination: (destination: NavigationRequest["destination"] | null) => void
   setPreference: (preference: NavigationRequest["preference"]) => void
@@ -46,6 +56,7 @@ interface NavigationContextValue {
    */
   pickRoomForActiveField: (room: Room) => void
   setNavigationPath?: (path: Node[] | undefined) => void
+  setNavigationDebug?: (debug: NavigationDebug | undefined) => void
 }
 
 const NavigationContext = createContext<NavigationContextValue | undefined>(undefined)
@@ -68,6 +79,7 @@ export const NavigationProvider = ({ children }: { children: React.ReactNode }) 
   const [navigationPanelOpen, setNavigationPanelOpen] = useState<boolean>(false)
   const [activeField, setActiveField] = useState<FieldKey | null>(null)
   const [navigationPath, setNavigationPath] = useState<Node[] | undefined>(undefined)
+  const [navigationDebug, setNavigationDebug] = useState<NavigationDebug | undefined>(undefined)
 
   // Wrap setStart / setDestination so every assignment also pans the map to
   // the chosen target. Covers all entry points: search bar, map click,
@@ -106,6 +118,7 @@ export const NavigationProvider = ({ children }: { children: React.ReactNode }) 
       navigationPanelOpen,
       activeField,
       navigationPath,
+      navigationDebug,
       setStart: handleSetStart,
       setDestination: handleSetDestination,
       setPreference,
@@ -113,6 +126,7 @@ export const NavigationProvider = ({ children }: { children: React.ReactNode }) 
       setActiveField,
       pickRoomForActiveField,
       setNavigationPath,
+      setNavigationDebug,
     }),
     [
       start,
@@ -121,6 +135,7 @@ export const NavigationProvider = ({ children }: { children: React.ReactNode }) 
       navigationPanelOpen,
       activeField,
       navigationPath,
+      navigationDebug,
       handleSetStart,
       handleSetDestination,
       pickRoomForActiveField,

--- a/src/server/astar.functions.ts
+++ b/src/server/astar.functions.ts
@@ -2,10 +2,10 @@ import { createServerFn } from "@tanstack/react-start"
 
 import { AstarInputSchema } from "#/types/navigation"
 
-import { astar } from "./astar.server"
+import { astarWithMetrics } from "./astar.metrics.server"
 
 export const astarFunction = createServerFn({ method: "GET" })
   .inputValidator(AstarInputSchema)
   .handler(async ({ data }) => {
-    return await astar(data.profile, data.dest, data.start)
+    return await astarWithMetrics(data.profile, data.dest, data.start)
   })

--- a/src/server/astar.metrics.server.ts
+++ b/src/server/astar.metrics.server.ts
@@ -1,0 +1,82 @@
+import { astar } from "./astar.server"
+
+import type { AstarInput, AstarMetrics, AstarResult } from "#/types/navigation"
+import type { Node } from "#/types/node"
+
+const TURN_ANGLE_THRESHOLD_DEG = 30
+
+const segmentDistance = (a: Node, b: Node): number => Math.hypot(b.x - a.x, b.y - a.y, b.z - a.z)
+
+/** Smallest absolute angle in degrees between segments (a→b) and (b→c). */
+const turnAngleDeg = (a: Node, b: Node, c: Node): number => {
+  const raw = Math.atan2(c.y - b.y, c.x - b.x) - Math.atan2(b.y - a.y, b.x - a.x)
+  // Wrap to (-π, π] without a loop: sin/cos round-trip is the canonical trick.
+  const wrapped = Math.atan2(Math.sin(raw), Math.cos(raw))
+  return Math.abs((wrapped * 180) / Math.PI)
+}
+
+const sumPathDistance = (path: Node[]): number => {
+  let total = 0
+  for (let i = 1; i < path.length; i++) total += segmentDistance(path[i - 1], path[i])
+  return total
+}
+
+const countFloorTransitions = (path: Node[]): number => {
+  let count = 0
+  for (let i = 1; i < path.length; i++) if (path[i].floor !== path[i - 1].floor) count++
+  return count
+}
+
+const countTurns = (path: Node[]): number => {
+  let count = 0
+  for (let i = 2; i < path.length; i++) {
+    if (turnAngleDeg(path[i - 2], path[i - 1], path[i]) > TURN_ANGLE_THRESHOLD_DEG) count++
+  }
+  return count
+}
+
+const emptyMetrics = (durationMs: number): AstarMetrics => ({
+  durationMs,
+  pathDistance: null,
+  floorTransitions: null,
+  turns: null,
+  detourRatio: null,
+})
+
+const metricsForPath = (path: Node[], durationMs: number): AstarMetrics => {
+  const start = path.at(0)
+  const end = path.at(-1)
+  if (!start || !end) return emptyMetrics(durationMs)
+  const pathDistance = sumPathDistance(path)
+  const straight = segmentDistance(start, end)
+  return {
+    durationMs,
+    pathDistance,
+    floorTransitions: countFloorTransitions(path),
+    turns: countTurns(path),
+    detourRatio: pathDistance > 0 ? straight / pathDistance : null,
+  }
+}
+
+/**
+ * Calls `astar` and decorates the result with timing + path-quality metrics.
+ * Nothing here touches the algorithm itself — all stats are derived from
+ * wall-clock and the returned node list, so `astar.server.ts` stays pristine.
+ */
+export const astarWithMetrics = async (
+  profile: AstarInput["profile"],
+  dest: AstarInput["dest"],
+  start: AstarInput["start"],
+): Promise<AstarResult> => {
+  const startedAt = performance.now()
+  const path = await astar(profile, dest, start)
+  const durationMs = performance.now() - startedAt
+
+  const metrics =
+    path && path.length > 1 ? metricsForPath(path, durationMs) : emptyMetrics(durationMs)
+
+  console.warn(
+    `[astar] ${durationMs.toFixed(2)}ms profile=${profile} pathLen=${path?.length ?? "null"}`,
+  )
+  return { path, metrics }
+}

--- a/src/server/astar.server.ts
+++ b/src/server/astar.server.ts
@@ -102,7 +102,9 @@ const heuristic = (
     }
   }
 
-  return Math.hypot(node.x - target.x, node.y - target.y, node.z - target.z) + turnPenalty + floorPenalty
+  return (
+    Math.hypot(node.x - target.x, node.y - target.y, node.z - target.z) + turnPenalty + floorPenalty
+  )
 }
 
 const findDestinationNode = (destRoom: AstarInput["dest"], startNode: Node): Node | null => {

--- a/src/server/astar.server.ts
+++ b/src/server/astar.server.ts
@@ -9,6 +9,7 @@ import type { AstarInput } from "#/types/navigation"
 
 const TURN_PENALTY = 1
 const TURN_ANGLE_THRESHOLD = 30 // degrees
+const FLOOR_CHANGE_PENALTY = 5
 
 const graph = await getGraph()
 
@@ -80,6 +81,7 @@ const heuristic = (
   }
 
   let turnPenalty = 0
+  let floorPenalty = 0
 
   if (profile === "SIMPLE" && previousEdge) {
     const fromNode = graph.nodes.get(previousEdge.fromNodeId)
@@ -93,7 +95,14 @@ const heuristic = (
     }
   }
 
-  return Math.hypot(node.x - target.x, node.y - target.y, node.z - target.z) + turnPenalty
+  if (previousEdge) {
+    const fromNode = graph.nodes.get(previousEdge.fromNodeId)
+    if (fromNode && fromNode.floor !== node.floor && node.floor === target.floor) {
+      floorPenalty = FLOOR_CHANGE_PENALTY
+    }
+  }
+
+  return Math.hypot(node.x - target.x, node.y - target.y, node.z - target.z) + turnPenalty + floorPenalty
 }
 
 const findDestinationNode = (destRoom: AstarInput["dest"], startNode: Node): Node | null => {

--- a/src/server/astar.server.ts
+++ b/src/server/astar.server.ts
@@ -131,6 +131,20 @@ export const astar = async (
   dest: AstarInput["dest"],
   start: AstarInput["start"],
 ) => {
+  const startedAt = performance.now()
+  const result = await runAstar(profile, dest, start)
+  const elapsedMs = performance.now() - startedAt
+  console.warn(
+    `[astar] ${elapsedMs.toFixed(2)}ms profile=${profile} pathLen=${result?.length ?? "null"}`,
+  )
+  return result
+}
+
+const runAstar = async (
+  profile: AstarInput["profile"],
+  dest: AstarInput["dest"],
+  start: AstarInput["start"],
+) => {
   // If start position is a node
   let firstNode: Node
   if ("id" in start) {

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -3,6 +3,8 @@ import { z } from "zod"
 import { RoomTypeSchema } from "./enums"
 import { NodeSchema } from "./node"
 
+import type { Node } from "./node"
+
 /**
  * Routing preferences offered to the user. Single source of truth — the UI,
  * the navigation context, and the A* server function all reference these
@@ -58,3 +60,32 @@ export const AstarInputSchema = z.object({
   start: NavigationStartSchema,
 })
 export type AstarInput = z.infer<typeof AstarInputSchema>
+
+/**
+ * Externally observable metrics for an A* run. Everything here is derived
+ * either from wall-clock timing or from walking the returned path — so
+ * none of it requires instrumenting the algorithm itself.
+ *
+ * Path-quality fields are `null` when no path was found.
+ */
+export interface AstarMetrics {
+  /** Server-side wall-clock spent inside the A* call (incl. start/dest resolution). */
+  durationMs: number
+  /** Sum of Euclidean distances between consecutive nodes on the returned path. */
+  pathDistance: number | null
+  /** Number of times the path crosses to a different floor. */
+  floorTransitions: number | null
+  /** Direction changes above the same threshold A* uses for the turn penalty. */
+  turns: number | null
+  /**
+   * Straight-line distance from start to goal divided by `pathDistance`.
+   * 1.0 means the path was a straight line; lower values mean it had to
+   * detour around walls, floors, or one-way edges.
+   */
+  detourRatio: number | null
+}
+
+export interface AstarResult {
+  path: Node[] | null
+  metrics: AstarMetrics
+}


### PR DESCRIPTION
## Description

Adds some performance stats for A*, visible client-side in debug mode. 

Shows pathfinding time + round-trip time including network latency.

Closes #, closes #, ...

## UI changes (Screenshots)

<img width="2228" height="1538" alt="Screenshot From 2026-05-16 17-31-03" src="https://github.com/user-attachments/assets/33c264b8-21d9-41c8-aaf7-b2b276ba1982" />


## Checklist

- [x] PR title follows the format `Feat/`, `Fix/` or `Chore/` (e.g. `Feat/Add A* pathfinding`)
- [x] Self-assigned this PR
- [x] Added relevant labels (e.g. `feature`, `fix`, `chore`)
- [ ] Linked a PBI from GitHub Projects
- [x] Manually tested the features touched by the files changed
- [x] Project builds locally (`pnpm build`)
- [x] No unrelated changes snuck in
