### PR TITLE
Fix/perspective camera

### DIFF
--- a/src/components/threeJS/camera-manager.tsx
+++ b/src/components/threeJS/camera-manager.tsx
@@ -1,0 +1,122 @@
+import { useThree } from "@react-three/fiber"
+import { useEffect, useRef } from "react"
+import * as THREE from "three"
+
+import { useMap } from "#/lib/map-context"
+
+/**
+ * Initial camera placement prop. Both cameras start here; subsequent state lives on the camera objects.
+ */
+const INITIAL_POSITION: [number, number, number] = [0, 50, 0]
+const INITIAL_ORTHO_ZOOM = 5
+const PERSP_FOV = 60
+const NEAR = 0.1
+const FAR = 1000
+
+/**
+ * Owns one `PerspectiveCamera` and one `OrthographicCamera`, swapping which
+ * one R3F renders with whenever `renderMode` flips. Without this, R3F's
+ * `<Canvas orthographic={…}>` only honours the prop on mount
+ *
+ * `<OrbitControls>` is recreated by drei when `state.camera` changes; its
+ * `target` prop is a stable `Vector3` ref from `MapScene`, so the orbit
+ * pivot survives the swap.
+ */
+export const CameraManager = () => {
+  const { renderMode, controlsRef } = useMap()
+  const { set, size } = useThree()
+
+  const perspRef = useRef<THREE.PerspectiveCamera | null>(null)
+  const orthoRef = useRef<THREE.OrthographicCamera | null>(null)
+  const didInitRef = useRef(false)
+
+  // Create the cameras once, after mount. R3F's default camera serves for
+  // the brief moment before this effect runs; the swap effect below then
+  // activates the right one via `set({ camera })`.
+  useEffect(() => {
+    const persp = new THREE.PerspectiveCamera(PERSP_FOV, size.width / size.height, NEAR, FAR)
+    persp.position.set(...INITIAL_POSITION)
+    persp.lookAt(0, 0, 0)
+    perspRef.current = persp
+
+    const ortho = new THREE.OrthographicCamera(
+      -size.width / 2,
+      size.width / 2,
+      size.height / 2,
+      -size.height / 2,
+      NEAR,
+      FAR,
+    )
+    ortho.position.set(...INITIAL_POSITION)
+    ortho.zoom = INITIAL_ORTHO_ZOOM
+    ortho.lookAt(0, 0, 0)
+    ortho.updateProjectionMatrix()
+    orthoRef.current = ortho
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Keep both cameras' frustums in sync with the canvas size.
+  useEffect(() => {
+    const persp = perspRef.current
+    if (persp) {
+      persp.aspect = size.width / size.height
+      persp.updateProjectionMatrix()
+    }
+    const ortho = orthoRef.current
+    if (ortho) {
+      ortho.left = -size.width / 2
+      ortho.right = size.width / 2
+      ortho.top = size.height / 2
+      ortho.bottom = -size.height / 2
+      ortho.updateProjectionMatrix()
+    }
+  }, [size.width, size.height])
+
+  // Activate the right camera on mount and every renderMode change. The first
+  // run skips the cross-camera sync - there's no previous view to preserve,
+  // and the initial values on each camera are already what we want.
+  useEffect(() => {
+    const persp = perspRef.current
+    const ortho = orthoRef.current
+    if (!persp || !ortho) return
+
+    const toCamera = renderMode === "2d" ? ortho : persp
+
+    if (didInitRef.current) {
+      const fromCamera = renderMode === "2d" ? persp : ortho
+      const target = controlsRef.current?.target ?? new THREE.Vector3(0, 0, 0)
+
+      // Match visible world span across the swap so the building doesn't
+      // appear to jump. Direction from target stays the same; only distance
+      // (perspective) or zoom (ortho) is recomputed.
+      const offset = fromCamera.position.clone().sub(target)
+      const dir = offset.lengthSq() > 0 ? offset.clone().normalize() : new THREE.Vector3(0, 1, 0)
+      const halfFov = THREE.MathUtils.degToRad(persp.fov / 2)
+
+      if (renderMode === "2d") {
+        // perspective → ortho. Match ortho's visible height (canvas / zoom)
+        // to the perspective's visible world height (2·d·tan(fov/2)).
+        const dist = offset.length()
+        const visibleH = 2 * dist * Math.tan(halfFov)
+        ortho.zoom = visibleH > 0 ? size.height / visibleH : INITIAL_ORTHO_ZOOM
+        ortho.position.copy(target).addScaledVector(dir, dist)
+        ortho.quaternion.copy(fromCamera.quaternion)
+        ortho.updateProjectionMatrix()
+      } else {
+        // ortho → perspective. Choose distance so perspective's visible
+        // height matches ortho's canvas/zoom.
+        const visibleH = size.height / Math.max(0.0001, ortho.zoom)
+        const newDist = visibleH / (2 * Math.tan(halfFov))
+        persp.position.copy(target).addScaledVector(dir, newDist)
+        persp.quaternion.copy(fromCamera.quaternion)
+        persp.updateProjectionMatrix()
+      }
+    } else {
+      didInitRef.current = true
+    }
+
+    set({ camera: toCamera })
+  }, [renderMode, set, size.height, controlsRef])
+
+  return null
+}

--- a/src/components/threeJS/camera-rig.tsx
+++ b/src/components/threeJS/camera-rig.tsx
@@ -30,11 +30,11 @@ interface OrbitControlsLike {
 }
 
 /**
- * Safety margin past the floor's farthest corner. Camera depth=0 plane must
- * not intersect any floor geometry — keep a small buffer so we don't sit
- * exactly on the boundary.
+ * Damping lambda for the soft push-out toward the dynamic minimum distance.
+ * High enough to feel responsive at high tilts; low enough that an orbit
+ * doesn't "ratchet" the camera outward in visible jumps.
  */
-const CAMERA_CLEARANCE_FACTOR = 1.05
+const MIN_DIST_DAMP_LAMBDA = 8
 
 interface CameraRigProps {
   activeFloor: number
@@ -77,13 +77,15 @@ export const CameraRig = ({ activeFloor, controlsRef, neighbourOpacityRef }: Cam
     const t = THREE.MathUtils.smoothstep(polarAngle, TILT_FADE_START, TILT_FADE_END)
     neighbourOpacityRef.current = t * NEIGHBOUR_MAX_OPACITY
 
-    // Raise minDistance with tilt so the whole floor stays in front of the
-    // camera. A floor point at projected radial distance `p` from the target
-    // along the camera's xz forward direction has depth `dist − sin(θ)·p`;
-    // to keep the farthest floor corner at depth > 0 we need
-    // `dist > sin(θ) · cornerRadius`. Without this, anything past the
-    // camera's xz position sits at depth ≤ 0 and WebGL slices it along a
-    // clean horizontal line at the bottom of the screen.
+    // Raise minDistance with tilt so the floor stays in front of the camera.
+    // A floor point at projected radial distance `p` from the target along
+    // the camera's xz forward direction has depth `dist − sin(θ)·p`; to keep
+    // the floor in view at depth > 0 we need `dist > sin(θ) · safeRadius`.
+    //
+    // Using `max(halfWidth, halfHeight)` instead of the diagonal corner
+    // distance trades some clipping at diagonal azimuths for much closer
+    // zoom in axis-aligned views (the common case). The push-out is damped
+    // so an orbit feels like a soft barrier instead of a hard ratchet.
     const extents = floorExtentsRef.current.get(activeFloor)
     if (extents) {
       const dx = Math.max(
@@ -94,17 +96,15 @@ export const CameraRig = ({ activeFloor, controlsRef, neighbourOpacityRef }: Cam
         Math.abs(controls.target.z - extents.halfHeight),
         Math.abs(controls.target.z + extents.halfHeight),
       )
-      const cornerRadius = Math.hypot(dx, dz) * CAMERA_CLEARANCE_FACTOR
-      const dynamicMin = Math.max(MIN_CAMERA_DISTANCE, Math.sin(polarAngle) * cornerRadius)
+      const safeRadius = Math.max(dx, dz)
+      const dynamicMin = Math.max(MIN_CAMERA_DISTANCE, Math.sin(polarAngle) * safeRadius)
       controls.minDistance = dynamicMin
 
-      // OrbitControls re-clamps radius to minDistance on zoom input, but tilt
-      // input doesn't — so a fresh tilt that just shrank the safe envelope
-      // would leave the camera inside it for a frame. Push it out now.
       const offset = controls.object.position.clone().sub(controls.target)
       const currentDist = offset.length()
       if (currentDist > 0 && currentDist < dynamicMin) {
-        offset.multiplyScalar(dynamicMin / currentDist)
+        const dampedDist = THREE.MathUtils.damp(currentDist, dynamicMin, MIN_DIST_DAMP_LAMBDA, dt)
+        offset.multiplyScalar(dampedDist / currentDist)
         controls.object.position.copy(controls.target).add(offset)
       }
     }

--- a/src/components/threeJS/map-scene.tsx
+++ b/src/components/threeJS/map-scene.tsx
@@ -6,6 +6,7 @@ import * as THREE from "three"
 import { useMap } from "#/lib/map-context"
 
 import { AdaptiveGrid } from "./adaptive-grid"
+import { CameraManager } from "./camera-manager"
 import { CameraRig } from "./camera-rig"
 import { ConnectEdgeLayer } from "./connect-edge-layer"
 import {
@@ -79,15 +80,14 @@ export const MapScene = () => {
     <Canvas
       gl={{ antialias: true }}
       scene={{ background: new THREE.Color("#333") }}
-      camera={{ fov: 60, near: 0.1, far: 1000, position: [0, 50, 0], zoom: 5 }}
       style={{
         width: "100%",
         height: "100%",
         cursor: activeTool === "default" ? "default" : "crosshair",
       }}
-      orthographic={renderMode === "2d"}
       onPointerMissed={handleBackgroundMiss}
     >
+      <CameraManager />
       <CameraRig
         activeFloor={activeFloor}
         controlsRef={controlsRef}

--- a/src/components/threeJS/navigation-path-layer.tsx
+++ b/src/components/threeJS/navigation-path-layer.tsx
@@ -15,6 +15,11 @@ import type { Node } from "#/types/node"
 
 const SHOW_ZOOM_THRESHOLD = 8
 const BASE_ZOOM = 20
+/** Distance at which the marker reaches full size in perspective mode. Picked
+ * to feel roughly equivalent to ortho's `BASE_ZOOM` ramp via the same
+ * REF_2D_ZOOM / REF_3D_DISTANCE proportion used elsewhere. */
+const BASE_DISTANCE_3D = 75
+const HIDE_DISTANCE_3D = 200
 
 interface FloorTransition {
   position: [number, number, number]
@@ -37,6 +42,18 @@ const FloorTransitionMarker = ({ transition: t }: { transition: FloorTransition 
       } else {
         el.style.display = "flex"
         const scale = Math.min(1, ortho.zoom / BASE_ZOOM)
+        el.style.transform = `scale(${scale})`
+      }
+    } else {
+      // Perspective: scale on inverse-distance so the marker stays roughly
+      // screen-stable. Hide when far enough away that the icon would shrink
+      // into illegibility.
+      const dist = camera.position.distanceTo(new THREE.Vector3(...t.position))
+      if (dist > HIDE_DISTANCE_3D) {
+        el.style.display = "none"
+      } else {
+        el.style.display = "flex"
+        const scale = Math.min(1, BASE_DISTANCE_3D / Math.max(1, dist))
         el.style.transform = `scale(${scale})`
       }
     }


### PR DESCRIPTION
## Description

Switches the 3D view from an orthographic camera to a true perspective camera, so distant parts of the building actually look distant. The 2D view keeps using the orthographic camera. A new `CameraManager` owns both cameras and swaps which one is active whenever the user toggles between 2D and 3D, preserving the view (where you're looking and how zoomed in you are) across the swap.

This is rebased on top of `fix/camera-clipping` #163  -> merge that one first.

Closes #

## How to run

1. Open a floor in the map view
2. Toggle between 2D and 3D modes — the view should stay roughly centered on the same spot at a similar zoom level (no jump)
3. In 3D mode, tilt the camera — you should see real perspective foreshortening (parallel walls converge into the distance), not the flat parallel look orthographic gives you
4. Check that floor-transition markers (stairs/elevators icons) scale sensibly with distance in 3D and disappear when you're very far away

## Changes made

- Added `CameraManager` component that owns one perspective and one orthographic camera, swapping the active one on `renderMode` change while matching visible world size so the view doesn't jump.
- Changed `MapScene` to render `<CameraManager />` instead of passing `camera` / `orthographic` props to `<Canvas>` (those props only apply on mount, which is why a runtime swap was needed).
- Added perspective-mode scaling and far-distance hiding for floor-transition markers in `navigation-path-layer.tsx` (the existing logic only handled the orthographic zoom case).
- Refactored the camera-clipping push-out in `CameraRig` to use a damped soft barrier instead of a hard snap, and to use the floor's larger half-extent rather than the full diagonal — this feels less "ratchety" during orbit and allows closer zoom in axis-aligned views.

## Checklist

- [x] PR title follows the format `Feat/`, `Fix/` or `Chore/` (e.g. `Feat/Add A* pathfinding`)
- [x] Self-assigned this PR
- [x] Added relevant labels (e.g. `feature`, `fix`, `chore`)
- [ ] Linked a PBI from GitHub Projects
- [x] Manually tested the features touched by the files changed
- [x] Project builds locally (`pnpm build`)
- [x] No unrelated changes snuck in
