### PR TITLE
Fix/ login race condition

### DIFF
--- a/src/components/login-form.tsx
+++ b/src/components/login-form.tsx
@@ -19,17 +19,15 @@ export const LoginForm = ({ className, ...props }: React.ComponentProps<"div">) 
     setError(null)
     setLoading(true)
 
-    const result = await authClient.signIn.username({
-      username: "admin",
-      password,
-    })
+    const result = await authClient.signIn.username(
+      { username: "admin", password },
+      { onSuccess: () => router.navigate({ to: "/" }) },
+    )
 
     setLoading(false)
 
     if (result.error) {
       setError(result.error.message ?? "Login failed")
-    } else {
-      await router.navigate({ to: "/" })
     }
   }
 

--- a/src/components/map/user-tools/auth-toggle.tsx
+++ b/src/components/map/user-tools/auth-toggle.tsx
@@ -40,7 +40,9 @@ export const AuthToggle = ({ className }: AuthToggleProps) => {
       className={className}
       onClick={() => {
         if (isLoggedIn) {
-          void authClient.signOut()
+          void authClient.signOut().then(() => {
+            globalThis.location.reload()
+          })
         } else {
           void navigate({ to: "/login" })
         }


### PR DESCRIPTION
## Description

Fixes a race condition on login causing the session state to be `undefined` upon immediate navigation, so that the admin menus don't pick up the changed state.

Solution: Wait for BetterAuth login to be successful, ensuring the auth state has been updated, not just that the login function has returned.

Closes #, closes #, ...

## Changes made

- Move navigation to login `onSuccess` callback

## UI changes (Screenshots)

N/A

## Checklist

- [x] PR title follows the format `Feat/`, `Fix/` or `Chore/` (e.g. `Feat/Add A* pathfinding`)
- [x] Self-assigned this PR
- [x] Added relevant labels (e.g. `feature`, `fix`, `chore`)
- [ ] Linked a PBI from GitHub Projects
- [x] Manually tested the features touched by the files changed
- [x] Project builds locally (`pnpm build`)
- [x] No unrelated changes snuck in
